### PR TITLE
fix: add prisma postinstall

### DIFF
--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -1,4 +1,11 @@
-export const simpleMessageSequence = [
+import type { Prisma, TestItemType } from "@prisma/client";
+
+export type TestItemFixture = {
+  type: TestItemType;
+  content: Prisma.InputJsonValue;
+};
+
+export const simpleMessageSequence: TestItemFixture[] = [
   {
     type: "message",
     content: {
@@ -15,7 +22,7 @@ export const simpleMessageSequence = [
   },
 ];
 
-export const weatherSequence = [
+export const weatherSequence: TestItemFixture[] = [
   {
     type: "message",
     content: {
@@ -54,7 +61,7 @@ export const weatherSequence = [
   },
 ];
 
-export const multiOutputSequence = [
+export const multiOutputSequence: TestItemFixture[] = [
   {
     type: "message",
     content: {
@@ -86,8 +93,8 @@ export const multiOutputSequence = [
   },
 ];
 
-export function withPositions<T extends { type: string; content: unknown }>(
-  items: T[]
+export function withPositions<T extends TestItemFixture>(
+  items: ReadonlyArray<T>
 ) {
   return items.map((item, index) => ({
     position: index,

--- a/e2e/responses/responses-api.test.ts
+++ b/e2e/responses/responses-api.test.ts
@@ -4,6 +4,7 @@ import { prisma } from "../helpers/prisma";
 import {
   multiOutputSequence,
   simpleMessageSequence,
+  TestItemFixture,
   weatherSequence,
   withPositions,
 } from "../helpers/fixtures";
@@ -17,7 +18,7 @@ async function seedResponseTest({
   orgSlug?: string;
   suiteName?: string;
   testName?: string;
-  items?: Array<{ type: string; content: unknown }>;
+  items?: ReadonlyArray<TestItemFixture>;
 }) {
   const org = await prisma.organization.create({
     data: { name: "Acme", slug: orgSlug },
@@ -342,7 +343,7 @@ describe("responses api", () => {
   });
 
   it("returns input_mismatch when input is shorter than expected", async () => {
-    const inputOnlySequence = [
+    const inputOnlySequence: TestItemFixture[] = [
       {
         type: "message",
         content: { role: "user", content: "First" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "testllm",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/adapter-pg": "^7.5.0",
         "@prisma/client": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "test:e2e": "vitest run --config vitest.config.e2e.ts"
+    "test:e2e": "vitest run --config vitest.config.e2e.ts",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.5.0",


### PR DESCRIPTION
## Summary
- add a postinstall hook to generate the Prisma client on fresh installs
- tighten E2E fixture typing to use Prisma JSON value types and TestItemType

## Testing
- rm -rf node_modules
- npm install
- npx tsc --noEmit
- npm run build
- npm run test
- npm run lint

Fixes #5