### PR TITLE
feat(ui): show response endpoints

### DIFF
--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/page.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/page.tsx
@@ -46,7 +46,7 @@ export default async function SuiteDetailPage({
     include: { _count: { select: { items: true } } },
   });
 
-  const endpoint = `/v1/org/${suite.org.slug}/suite/${suite.name}/responses`;
+  const endpoint = `https://testllm.dev/v1/org/${suite.org.slug}/suite/${suite.name}/responses`;
 
   return (
     <div className="space-y-6">
@@ -144,9 +144,9 @@ export default async function SuiteDetailPage({
         </CardHeader>
         <CardContent className="flex flex-wrap items-center justify-between gap-3">
           <code className="rounded bg-muted px-2 py-1 text-sm font-mono">
-            POST {endpoint}
+            {endpoint}
           </code>
-          <CopyButton value={`POST ${endpoint}`} showLabel />
+          <CopyButton value={endpoint} showLabel />
         </CardContent>
       </Card>
     </div>

--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/page.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/page.tsx
@@ -36,6 +36,7 @@ export default async function TestDetailPage({
   });
 
   const listItems = mapPrismaItemsToListItems(items);
+  const endpoint = `https://testllm.dev/v1/org/${test.testSuite.org.slug}/suite/${test.testSuite.name}/responses`;
 
   return (
     <div className="space-y-6">
@@ -94,6 +95,21 @@ export default async function TestDetailPage({
             {test.name}
           </code>
           <CopyButton value={test.name} showLabel />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Endpoint</CardTitle>
+          <CardDescription>
+            Use this endpoint when configuring your agent.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap items-center justify-between gap-3">
+          <code className="rounded bg-muted px-2 py-1 text-sm font-mono">
+            {endpoint}
+          </code>
+          <CopyButton value={endpoint} showLabel />
         </CardContent>
       </Card>
     </div>

--- a/src/lib/test-helpers.ts
+++ b/src/lib/test-helpers.ts
@@ -49,7 +49,7 @@ export async function findTestOrNull(
 ) {
   const test = await prisma.test.findUnique({
     where: { id: testId },
-    include: { testSuite: true },
+    include: { testSuite: { include: { org: true } } },
   });
   if (!test) return null;
   if (test.testSuiteId !== suiteId) return null;


### PR DESCRIPTION
## Summary
- update suite endpoint display with full https URL
- add test detail endpoint card using org slug and suite name
- include org relation in test lookup

## Testing
- env $(cat .env.test | xargs) npm run lint
- env $(cat .env.test | xargs) npm run test
- env $(cat .env.test | xargs) npm run test:e2e

Closes #17