### PR TITLE
feat(responses): add SSE streaming support

### DIFF
--- a/e2e/responses/responses-api.test.ts
+++ b/e2e/responses/responses-api.test.ts
@@ -9,6 +9,29 @@ import {
   withPositions,
 } from "../helpers/fixtures";
 
+async function readSseEvents(response: Response) {
+  const text = await response.text();
+
+  return text
+    .trim()
+    .split("\n\n")
+    .filter(Boolean)
+    .map((chunk) => {
+      const lines = chunk.split("\n");
+      const eventLine = lines.find((line) => line.startsWith("event: "));
+      const dataLine = lines.find((line) => line.startsWith("data: "));
+
+      if (!eventLine || !dataLine) {
+        throw new Error("Invalid SSE frame");
+      }
+
+      return {
+        event: eventLine.slice("event: ".length),
+        data: JSON.parse(dataLine.slice("data: ".length)),
+      };
+    });
+}
+
 async function seedResponseTest({
   orgSlug = "acme",
   suiteName = "default",
@@ -153,14 +176,19 @@ describe("responses api", () => {
     });
   });
 
-  it("matches array input items", async () => {
+  it("matches array content without streaming", async () => {
     const { org, suite, test } = await seedResponseTest({});
 
     const response = await fetch(responsesUrl(org.slug, suite.name), {
       method: "POST",
       ...jsonRequest({
         model: test.name,
-        input: [{ role: "user", content: "Hello there" }],
+        input: [
+          {
+            role: "user",
+            content: [{ type: "input_text", text: "Hello there" }],
+          },
+        ],
       }),
     });
 
@@ -270,6 +298,197 @@ describe("responses api", () => {
       status: "completed",
     });
     expect(body.output[0].id).toMatch(/^fc_/);
+  });
+
+  it("streams a simple message response as SSE", async () => {
+    const { org, suite, test } = await seedResponseTest({});
+
+    const response = await fetch(responsesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: test.name,
+        stream: true,
+        input: [{ role: "user", content: "Hello there" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain(
+      "text/event-stream"
+    );
+
+    const events = await readSseEvents(response);
+    expect(events.map((event) => event.event)).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.content_part.added",
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.content_part.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+
+    events.forEach(({ event, data }) => {
+      expect(data.type).toBe(event);
+    });
+
+    const addedItem = events[2].data.item as { id: string; status: string };
+    expect(addedItem.status).toBe("in_progress");
+
+    const deltaEvent = events[4].data as { delta: string; item_id: string };
+    expect(deltaEvent.delta).toBe("Hi! How can I help?");
+    expect(deltaEvent.item_id).toBe(addedItem.id);
+
+    const completed = events[8].data as {
+      response: { output: Array<{ content: Array<{ text: string }> }> };
+    };
+    expect(completed.response.output[0].content[0].text).toBe(
+      "Hi! How can I help?"
+    );
+  });
+
+  it("streams function_call outputs", async () => {
+    const { org, suite, test } = await seedResponseTest({
+      items: weatherSequence,
+      testName: "weather-stream",
+    });
+
+    const response = await fetch(responsesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: test.name,
+        stream: true,
+        input: [
+          { role: "system", content: "You are a weather assistant." },
+          { role: "user", content: "What is the weather in SF?" },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const events = await readSseEvents(response);
+    expect(events.map((event) => event.event)).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+
+    const addedItem = events[2].data.item as {
+      status: string;
+      call_id: string;
+      arguments: string;
+    };
+    expect(addedItem.status).toBe("in_progress");
+    expect(addedItem.call_id).toBe("call_weather");
+    expect(addedItem.arguments).toBe("");
+
+    const deltaEvent = events[3].data as { delta: string };
+    expect(deltaEvent.delta).toBe("{\"city\":\"SF\"}");
+
+    const doneEvent = events[4].data as { name: string; arguments: string };
+    expect(doneEvent.name).toBe("get_weather");
+    expect(doneEvent.arguments).toBe("{\"city\":\"SF\"}");
+  });
+
+  it("streams multiple output items with correct output indexes", async () => {
+    const { org, suite, test } = await seedResponseTest({
+      items: multiOutputSequence,
+      testName: "multi-stream",
+    });
+
+    const response = await fetch(responsesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: test.name,
+        stream: true,
+        input: [{ role: "user", content: "Run the workflow" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const events = await readSseEvents(response);
+    const addedIndexes = events
+      .filter((event) => event.event === "response.output_item.added")
+      .map((event) => (event.data as { output_index: number }).output_index);
+    const doneIndexes = events
+      .filter((event) => event.event === "response.output_item.done")
+      .map((event) => (event.data as { output_index: number }).output_index);
+
+    expect(addedIndexes).toEqual([0, 1]);
+    expect(doneIndexes).toEqual([0, 1]);
+  });
+
+  it("streams responses when input uses typed content", async () => {
+    const { org, suite, test } = await seedResponseTest({});
+
+    const response = await fetch(responsesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: test.name,
+        stream: true,
+        input: [
+          {
+            role: "user",
+            content: [
+              { type: "input_text", text: "Hello " },
+              { type: "input_text", text: "there" },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const events = await readSseEvents(response);
+    const completed = events.find(
+      (event) => event.event === "response.completed"
+    );
+
+    expect(completed?.data.response.output[0].content[0].text).toBe(
+      "Hi! How can I help?"
+    );
+  });
+
+  it("returns JSON when stream is false", async () => {
+    const { org, suite, test } = await seedResponseTest({});
+
+    const response = await fetch(responsesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: test.name,
+        stream: false,
+        input: [{ role: "user", content: "Hello there" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain(
+      "application/json"
+    );
+    const body = await response.json();
+    expect(body.output).toHaveLength(1);
+  });
+
+  it("returns JSON errors even when stream is true", async () => {
+    const response = await fetch(responsesUrl("acme", "default"), {
+      method: "POST",
+      ...jsonRequest({ model: "test", input: 123, stream: true }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toContain(
+      "application/json"
+    );
+    const body = await response.json();
+    expect(body.error).toMatchObject({ code: "invalid_request" });
   });
 
   it("returns input_mismatch for content differences", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -364,7 +365,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -4262,6 +4264,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4272,6 +4275,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4321,6 +4325,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -4961,6 +4966,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5336,6 +5342,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6195,6 +6202,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6380,6 +6388,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7211,6 +7220,7 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8861,6 +8871,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9145,6 +9156,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9176,6 +9188,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.5.0",
         "@prisma/dev": "0.20.0",
@@ -9375,6 +9388,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9384,6 +9398,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10350,6 +10365,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10551,6 +10567,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10757,6 +10774,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10873,6 +10891,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11150,6 +11169,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/v1/org/[orgSlug]/suite/[suiteName]/responses/route.ts
+++ b/src/app/v1/org/[orgSlug]/suite/[suiteName]/responses/route.ts
@@ -9,12 +9,13 @@ import {
   normalizeInput,
   parseTestSequence,
 } from "@/lib/responses/matching";
-import { formatResponse } from "@/lib/responses/formatting";
+import { formatResponse, formatSSEStream } from "@/lib/responses/formatting";
 
 const RequestSchema = z
   .object({
     model: z.string().min(1, { message: "model is required" }),
     input: InputSchema,
+    stream: z.boolean().optional(),
   })
   .passthrough();
 
@@ -110,7 +111,7 @@ export async function POST(
   const parsedRequest = await parseRequestBody(request);
   if (!parsedRequest.ok) return parsedRequest.error;
 
-  const { model, input } = parsedRequest.data;
+  const { model, input, stream } = parsedRequest.data;
   const normalizedInput = normalizeInput(input);
 
   const org = await prisma.organization.findUnique({
@@ -158,6 +159,16 @@ export async function POST(
   const result = matchInput(sequence, normalizedInput);
   if (isMatchError(result)) {
     return openaiError(result.status, result.message, result.type, result.code);
+  }
+
+  if (stream) {
+    const streamBody = formatSSEStream(model, result.outputItems);
+    return new Response(streamBody, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      },
+    });
   }
 
   const response = formatResponse(model, result.outputItems);

--- a/src/lib/responses/__tests__/formatting.test.ts
+++ b/src/lib/responses/__tests__/formatting.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { formatSSEStream } from "@/lib/responses/formatting";
+import type { OutputTestItem, SSEEvent } from "@/lib/responses/types";
+
+async function readStream(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+
+  output += decoder.decode();
+  return output;
+}
+
+function parseSSE(text: string) {
+  return text
+    .trim()
+    .split("\n\n")
+    .filter(Boolean)
+    .map((chunk) => {
+      const lines = chunk.split("\n");
+      const eventLine = lines.find((line) => line.startsWith("event: "));
+      const dataLine = lines.find((line) => line.startsWith("data: "));
+
+      if (!eventLine || !dataLine) {
+        throw new Error("Invalid SSE frame");
+      }
+
+      const event = eventLine.slice("event: ".length);
+      const data = JSON.parse(dataLine.slice("data: ".length)) as SSEEvent;
+      return { event, data };
+    });
+}
+
+function messageItem(text: string): OutputTestItem {
+  return {
+    id: "msg-1",
+    position: 0,
+    type: "message",
+    content: { role: "assistant", content: text },
+  };
+}
+
+function functionCallItem(args: string): OutputTestItem {
+  return {
+    id: "fc-1",
+    position: 0,
+    type: "function_call",
+    content: { call_id: "call-1", name: "get_weather", arguments: args },
+  };
+}
+
+describe("formatSSEStream", () => {
+  it("formats message output into SSE events", async () => {
+    const stream = formatSSEStream("simple", [messageItem("Hello there")]);
+    const events = parseSSE(await readStream(stream));
+    const eventTypes = events.map((event) => event.event);
+
+    expect(eventTypes).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.content_part.added",
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.content_part.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+
+    events.forEach(({ event, data }) => {
+      expect(data.type).toBe(event);
+    });
+
+    const addedItem = events[2].data as { item: { id: string; status: string } };
+    const addedItemId = addedItem.item.id;
+    expect(addedItem.item.status).toBe("in_progress");
+
+    const deltaEvent = events[4].data as { delta: string; item_id: string };
+    expect(deltaEvent.delta).toBe("Hello there");
+    expect(deltaEvent.item_id).toBe(addedItemId);
+
+    const completedEvent = events[8].data as {
+      response: { output: Array<{ content: Array<{ text: string }> }> };
+    };
+    expect(completedEvent.response.output[0].content[0].text).toBe(
+      "Hello there"
+    );
+  });
+
+  it("formats function_call output into SSE events", async () => {
+    const stream = formatSSEStream("weather", [
+      functionCallItem("{\"city\":\"SF\"}"),
+    ]);
+    const events = parseSSE(await readStream(stream));
+    const eventTypes = events.map((event) => event.event);
+
+    expect(eventTypes).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+
+    const addedItem = events[2].data as { item: { arguments: string } };
+    expect(addedItem.item.arguments).toBe("");
+
+    const deltaEvent = events[3].data as { delta: string };
+    expect(deltaEvent.delta).toBe("{\"city\":\"SF\"}");
+
+    const doneEvent = events[4].data as { arguments: string; name: string };
+    expect(doneEvent.name).toBe("get_weather");
+    expect(doneEvent.arguments).toBe("{\"city\":\"SF\"}");
+  });
+
+  it("assigns output_index values for multiple outputs", async () => {
+    const stream = formatSSEStream("multi", [
+      functionCallItem("{}"),
+      messageItem("Done"),
+    ]);
+    const events = parseSSE(await readStream(stream));
+
+    const addedIndexes = events
+      .filter((event) => event.event === "response.output_item.added")
+      .map((event) => (event.data as { output_index: number }).output_index);
+    const doneIndexes = events
+      .filter((event) => event.event === "response.output_item.done")
+      .map((event) => (event.data as { output_index: number }).output_index);
+
+    expect(addedIndexes).toEqual([0, 1]);
+    expect(doneIndexes).toEqual([0, 1]);
+  });
+
+  it("emits monotonically increasing sequence numbers", async () => {
+    const stream = formatSSEStream("sequence", [messageItem("Step")]);
+    const events = parseSSE(await readStream(stream));
+    const sequenceNumbers = events.map(
+      (event) => (event.data as { sequence_number: number }).sequence_number
+    );
+
+    expect(sequenceNumbers).toEqual(
+      Array.from({ length: events.length }, (_, index) => index)
+    );
+  });
+});

--- a/src/lib/responses/__tests__/matching.test.ts
+++ b/src/lib/responses/__tests__/matching.test.ts
@@ -125,6 +125,45 @@ describe("matchInput", () => {
     ]);
   });
 
+  it("keeps string content unchanged in array input", () => {
+    const normalized = normalizeInput([
+      { role: "user", content: "Hello there" },
+    ]);
+
+    expect(normalized).toEqual([
+      { type: "message", role: "user", content: "Hello there" },
+    ]);
+  });
+
+  it("normalizes array content into a single string", () => {
+    const normalized = normalizeInput([
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "Hello" }],
+      },
+    ]);
+
+    expect(normalized).toEqual([
+      { type: "message", role: "user", content: "Hello" },
+    ]);
+  });
+
+  it("concatenates multi-part array content", () => {
+    const normalized = normalizeInput([
+      {
+        role: "user",
+        content: [
+          { type: "input_text", text: "Hello " },
+          { type: "input_text", text: "there" },
+        ],
+      },
+    ]);
+
+    expect(normalized).toEqual([
+      { type: "message", role: "user", content: "Hello there" },
+    ]);
+  });
+
   it("returns a mismatch when input differs", () => {
     const sequence = [
       messageItem(0, "user", "Expected"),

--- a/src/lib/responses/formatting.ts
+++ b/src/lib/responses/formatting.ts
@@ -2,8 +2,20 @@ import { randomUUID } from "crypto";
 import type {
   OpenAIOutputItem,
   OpenAIResponse,
+  OpenAIResponseCompleted,
+  OpenAIResponseInProgress,
+  OutputTextContentPart,
   OutputTestItem,
+  SSEEvent,
 } from "@/lib/responses/types";
+
+function outputTextPart(text: string): OutputTextContentPart {
+  return {
+    type: "output_text",
+    text,
+    annotations: [],
+  };
+}
 
 export function formatOutputItem(item: OutputTestItem): OpenAIOutputItem {
   if (item.type === "message") {
@@ -12,13 +24,7 @@ export function formatOutputItem(item: OutputTestItem): OpenAIOutputItem {
       type: "message",
       role: "assistant",
       status: "completed",
-      content: [
-        {
-          type: "output_text",
-          text: item.content.content,
-          annotations: [],
-        },
-      ],
+      content: [outputTextPart(item.content.content)],
     };
   }
 
@@ -44,4 +50,198 @@ export function formatResponse(
     output: outputItems.map(formatOutputItem),
     status: "completed",
   };
+}
+
+export function formatSSEStream(
+  model: string,
+  outputItems: OutputTestItem[]
+): ReadableStream<Uint8Array> {
+  const responseId = `resp_${randomUUID()}`;
+  const createdAt = Math.floor(Date.now() / 1000);
+  const events: SSEEvent[] = [];
+  const completedOutput: OpenAIOutputItem[] = [];
+  let sequenceNumber = 0;
+
+  const baseResponse: OpenAIResponseInProgress = {
+    id: responseId,
+    object: "response",
+    created_at: createdAt,
+    model,
+    output: [],
+    status: "in_progress",
+    usage: null,
+  };
+
+  events.push({
+    type: "response.created",
+    response: baseResponse,
+    sequence_number: sequenceNumber++,
+  });
+  events.push({
+    type: "response.in_progress",
+    response: baseResponse,
+    sequence_number: sequenceNumber++,
+  });
+
+  outputItems.forEach((item, outputIndex) => {
+    if (item.type === "message") {
+      const itemId = `msg_${randomUUID()}`;
+      const text = item.content.content;
+      const addedItem: OpenAIOutputItem = {
+        id: itemId,
+        type: "message",
+        role: "assistant",
+        status: "in_progress",
+        content: [],
+      };
+
+      events.push({
+        type: "response.output_item.added",
+        output_index: outputIndex,
+        item: addedItem,
+        sequence_number: sequenceNumber++,
+      });
+
+      events.push({
+        type: "response.content_part.added",
+        item_id: itemId,
+        output_index: outputIndex,
+        content_index: 0,
+        part: outputTextPart(""),
+        sequence_number: sequenceNumber++,
+      });
+
+      events.push({
+        type: "response.output_text.delta",
+        item_id: itemId,
+        output_index: outputIndex,
+        content_index: 0,
+        delta: text,
+        sequence_number: sequenceNumber++,
+      });
+
+      events.push({
+        type: "response.output_text.done",
+        item_id: itemId,
+        output_index: outputIndex,
+        content_index: 0,
+        text,
+        sequence_number: sequenceNumber++,
+      });
+
+      const completedPart = outputTextPart(text);
+      events.push({
+        type: "response.content_part.done",
+        item_id: itemId,
+        output_index: outputIndex,
+        content_index: 0,
+        part: completedPart,
+        sequence_number: sequenceNumber++,
+      });
+
+      const completedItem: OpenAIOutputItem = {
+        id: itemId,
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [completedPart],
+      };
+
+      events.push({
+        type: "response.output_item.done",
+        output_index: outputIndex,
+        item: completedItem,
+        sequence_number: sequenceNumber++,
+      });
+
+      completedOutput.push(completedItem);
+      return;
+    }
+
+    const itemId = `fc_${randomUUID()}`;
+    const addedItem: OpenAIOutputItem = {
+      id: itemId,
+      type: "function_call",
+      call_id: item.content.call_id,
+      name: item.content.name,
+      arguments: "",
+      status: "in_progress",
+    };
+
+    events.push({
+      type: "response.output_item.added",
+      output_index: outputIndex,
+      item: addedItem,
+      sequence_number: sequenceNumber++,
+    });
+
+    events.push({
+      type: "response.function_call_arguments.delta",
+      item_id: itemId,
+      output_index: outputIndex,
+      delta: item.content.arguments,
+      sequence_number: sequenceNumber++,
+    });
+
+    events.push({
+      type: "response.function_call_arguments.done",
+      item_id: itemId,
+      output_index: outputIndex,
+      name: item.content.name,
+      arguments: item.content.arguments,
+      sequence_number: sequenceNumber++,
+    });
+
+    const completedItem: OpenAIOutputItem = {
+      id: itemId,
+      type: "function_call",
+      call_id: item.content.call_id,
+      name: item.content.name,
+      arguments: item.content.arguments,
+      status: "completed",
+    };
+
+    events.push({
+      type: "response.output_item.done",
+      output_index: outputIndex,
+      item: completedItem,
+      sequence_number: sequenceNumber++,
+    });
+
+    completedOutput.push(completedItem);
+  });
+
+  const completedResponse: OpenAIResponseCompleted = {
+    id: responseId,
+    object: "response",
+    created_at: createdAt,
+    model,
+    output: completedOutput,
+    status: "completed",
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+    },
+  };
+
+  events.push({
+    type: "response.completed",
+    response: completedResponse,
+    sequence_number: sequenceNumber++,
+  });
+
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        const payload =
+          `event: ${event.type}\n` +
+          `data: ${JSON.stringify(event)}\n\n`;
+        controller.enqueue(encoder.encode(payload));
+      }
+      controller.close();
+    },
+  });
 }

--- a/src/lib/responses/matching.ts
+++ b/src/lib/responses/matching.ts
@@ -5,10 +5,20 @@ import type {
   TestItemRecord,
 } from "@/lib/responses/types";
 
+const InputMessageContentPartSchema = z.object({
+  type: z.literal("input_text"),
+  text: z.string(),
+});
+
+const InputMessageContentSchema = z.union([
+  z.string(),
+  z.array(InputMessageContentPartSchema),
+]);
+
 const InputMessageSchema = z.object({
   type: z.literal("message").optional(),
   role: z.enum(["user", "system", "developer"]),
-  content: z.string(),
+  content: InputMessageContentSchema,
 });
 
 const InputFunctionCallSchema = z.object({
@@ -33,6 +43,7 @@ const InputItemSchema = z.union([
 export const InputSchema = z.union([z.string(), z.array(InputItemSchema)]);
 
 type InputSchemaValue = z.infer<typeof InputSchema>;
+type InputMessageContent = z.infer<typeof InputMessageContentSchema>;
 
 const StoredMessageContentSchema = z.object({
   role: z.enum(["user", "system", "developer", "assistant"]),
@@ -128,9 +139,14 @@ export function normalizeInput(input: InputSchemaValue): NormalizedInputItem[] {
     return {
       type: "message",
       role: item.role,
-      content: item.content,
+      content: normalizeMessageContent(item.content),
     };
   });
+}
+
+function normalizeMessageContent(content: InputMessageContent): string {
+  if (typeof content === "string") return content;
+  return content.map((part) => part.text).join("");
 }
 
 // Internal matching logic (assumes validated inputs).

--- a/src/lib/responses/types.ts
+++ b/src/lib/responses/types.ts
@@ -77,16 +77,18 @@ export type NormalizedInputItem =
   | NormalizedInputFunctionCall
   | NormalizedInputFunctionCallOutput;
 
+export interface OutputTextContentPart {
+  type: "output_text";
+  text: string;
+  annotations: [];
+}
+
 export interface OpenAIOutputMessage {
   id: string;
   type: "message";
   role: "assistant";
-  status: "completed";
-  content: Array<{
-    type: "output_text";
-    text: string;
-    annotations: [];
-  }>;
+  status: "completed" | "in_progress";
+  content: OutputTextContentPart[];
 }
 
 export interface OpenAIOutputFunctionCall {
@@ -95,7 +97,7 @@ export interface OpenAIOutputFunctionCall {
   call_id: string;
   name: string;
   arguments: string;
-  status: "completed";
+  status: "completed" | "in_progress";
 }
 
 export type OpenAIOutputItem =
@@ -110,3 +112,127 @@ export interface OpenAIResponse {
   output: OpenAIOutputItem[];
   status: "completed";
 }
+
+export interface OpenAIUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+}
+
+export interface OpenAIResponseInProgress {
+  id: string;
+  object: "response";
+  created_at: number;
+  model: string;
+  output: [];
+  status: "in_progress";
+  usage: null;
+}
+
+export interface OpenAIResponseCompleted {
+  id: string;
+  object: "response";
+  created_at: number;
+  model: string;
+  output: OpenAIOutputItem[];
+  status: "completed";
+  usage: OpenAIUsage;
+}
+
+export interface ResponseCreatedEvent {
+  type: "response.created";
+  response: OpenAIResponseInProgress;
+  sequence_number: number;
+}
+
+export interface ResponseInProgressEvent {
+  type: "response.in_progress";
+  response: OpenAIResponseInProgress;
+  sequence_number: number;
+}
+
+export interface ResponseOutputItemAddedEvent {
+  type: "response.output_item.added";
+  output_index: number;
+  item: OpenAIOutputItem;
+  sequence_number: number;
+}
+
+export interface ResponseContentPartAddedEvent {
+  type: "response.content_part.added";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+  part: OutputTextContentPart;
+  sequence_number: number;
+}
+
+export interface ResponseOutputTextDeltaEvent {
+  type: "response.output_text.delta";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+  delta: string;
+  sequence_number: number;
+}
+
+export interface ResponseOutputTextDoneEvent {
+  type: "response.output_text.done";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+  text: string;
+  sequence_number: number;
+}
+
+export interface ResponseContentPartDoneEvent {
+  type: "response.content_part.done";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+  part: OutputTextContentPart;
+  sequence_number: number;
+}
+
+export interface ResponseFunctionCallArgumentsDeltaEvent {
+  type: "response.function_call_arguments.delta";
+  item_id: string;
+  output_index: number;
+  delta: string;
+  sequence_number: number;
+}
+
+export interface ResponseFunctionCallArgumentsDoneEvent {
+  type: "response.function_call_arguments.done";
+  item_id: string;
+  output_index: number;
+  name: string;
+  arguments: string;
+  sequence_number: number;
+}
+
+export interface ResponseOutputItemDoneEvent {
+  type: "response.output_item.done";
+  output_index: number;
+  item: OpenAIOutputItem;
+  sequence_number: number;
+}
+
+export interface ResponseCompletedEvent {
+  type: "response.completed";
+  response: OpenAIResponseCompleted;
+  sequence_number: number;
+}
+
+export type SSEEvent =
+  | ResponseCreatedEvent
+  | ResponseInProgressEvent
+  | ResponseOutputItemAddedEvent
+  | ResponseContentPartAddedEvent
+  | ResponseOutputTextDeltaEvent
+  | ResponseOutputTextDoneEvent
+  | ResponseContentPartDoneEvent
+  | ResponseFunctionCallArgumentsDeltaEvent
+  | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseOutputItemDoneEvent
+  | ResponseCompletedEvent;


### PR DESCRIPTION
## Summary
- add SSE stream formatting and event types for Responses API
- normalize array content input_text parts for matching
- add streaming/unit/E2E coverage for SSE responses

## Testing
- env $(cat .env.test | xargs) npm run lint
- env $(cat .env.test | xargs) npm run test
- env $(cat .env.test | xargs) npm run test:e2e

#19