### PR TITLE
fix(responses): accept assistant inputs

### DIFF
--- a/src/lib/responses/__tests__/matching.test.ts
+++ b/src/lib/responses/__tests__/matching.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  InputSchema,
   isMatchError,
   matchInput,
   normalizeInput,
@@ -95,6 +96,37 @@ describe("matchInput", () => {
     if (!isMatchError(secondResult)) {
       expect(secondResult.outputItems).toHaveLength(1);
       expect(secondResult.outputItems[0].type).toBe("message");
+    }
+  });
+
+  it("matches multi-turn input with assistant messages", () => {
+    const sequence = [
+      messageItem(0, "system", "System prompt"),
+      messageItem(1, "user", "Hello"),
+      messageItem(2, "assistant", "Hi there"),
+      messageItem(3, "user", "How are you?"),
+      messageItem(4, "assistant", "Doing great"),
+    ];
+
+    const parsedInput = InputSchema.parse([
+      { role: "system", content: "System prompt" },
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+      { role: "user", content: "How are you?" },
+    ]);
+
+    const result = matchInput(sequence, normalizeInput(parsedInput));
+
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputItems).toHaveLength(1);
+      expect(result.outputItems[0].type).toBe("message");
+      if (result.outputItems[0].type === "message") {
+        expect(result.outputItems[0].content).toEqual({
+          role: "assistant",
+          content: "Doing great",
+        });
+      }
     }
   });
 

--- a/src/lib/responses/matching.ts
+++ b/src/lib/responses/matching.ts
@@ -17,7 +17,7 @@ const InputMessageContentSchema = z.union([
 
 const InputMessageSchema = z.object({
   type: z.literal("message").optional(),
-  role: z.enum(["user", "system", "developer"]),
+  role: z.enum(["user", "system", "developer", "assistant"]),
   content: InputMessageContentSchema,
 });
 

--- a/src/lib/responses/types.ts
+++ b/src/lib/responses/types.ts
@@ -55,7 +55,7 @@ export type OutputTestItem =
 
 export interface NormalizedInputMessage {
   type: "message";
-  role: InputMessageRole;
+  role: MessageRole;
   content: string;
 }
 


### PR DESCRIPTION
## Summary
- allow assistant role in Responses input schema/normalized types
- add matching test for multi-turn assistant input messages

## Testing
- env $(cat .env.test | xargs) npm run lint
- env $(cat .env.test | xargs) npm run test

Refs #22