### PR TITLE
feat: add repeat wildcard flag for greedy input matching

### DIFF
--- a/src/components/test-item-editor/types.ts
+++ b/src/components/test-item-editor/types.ts
@@ -3,6 +3,7 @@ export type MessageContent = {
   content: string;
   any_role?: boolean;
   any_content?: boolean;
+  repeat?: boolean;
 };
 
 export type FunctionCallContent = {

--- a/src/lib/responses/__tests__/matching.test.ts
+++ b/src/lib/responses/__tests__/matching.test.ts
@@ -14,7 +14,7 @@ const messageItem = (
   position: number,
   role: MessageRole,
   content: string,
-  options?: { any_role?: boolean; any_content?: boolean }
+  options?: { any_role?: boolean; any_content?: boolean; repeat?: boolean }
 ): TestItemRecord => ({
   id: `msg-${position}`,
   position,
@@ -237,6 +237,95 @@ describe("matchInput", () => {
     ];
     const input = normalizeInput([
       { role: "system", content: "Different content" },
+    ]);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputItems).toHaveLength(1);
+      expect(result.outputItems[0].type).toBe("message");
+    }
+  });
+
+  it("matches repeat wildcard absorbing multiple input items", () => {
+    const sequence = [
+      messageItem(0, "user", "Wildcard", {
+        any_role: true,
+        any_content: true,
+        repeat: true,
+      }),
+      messageItem(1, "user", "hi"),
+      messageItem(2, "assistant", "Output"),
+    ];
+    const input = normalizeInput([
+      { role: "system", content: "Environment context" },
+      { role: "user", content: "hi" },
+    ]);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputItems).toHaveLength(1);
+      expect(result.outputItems[0].type).toBe("message");
+    }
+  });
+
+  it("matches repeat wildcard absorbing many input items", () => {
+    const sequence = [
+      messageItem(0, "user", "Wildcard", {
+        any_role: true,
+        any_content: true,
+        repeat: true,
+      }),
+      messageItem(1, "user", "hi"),
+      messageItem(2, "assistant", "Output"),
+    ];
+    const input = normalizeInput([
+      { role: "developer", content: "Developer instructions" },
+      { role: "system", content: "Environment context" },
+      { role: "user", content: "agents.md" },
+      { role: "user", content: "hi" },
+    ]);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputItems).toHaveLength(1);
+      expect(result.outputItems[0].type).toBe("message");
+    }
+  });
+
+  it("repeat wildcard requires at least one match", () => {
+    const sequence = [
+      messageItem(0, "user", "Wildcard", {
+        any_role: true,
+        any_content: true,
+        repeat: true,
+      }),
+      messageItem(1, "user", "hi"),
+      messageItem(2, "assistant", "Output"),
+    ];
+    const input = normalizeInput([{ role: "user", content: "hi" }]);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(true);
+    if (isMatchError(result)) {
+      expect(result.code).toBe("input_mismatch");
+    }
+  });
+
+  it("non-repeat wildcards still match exactly one item", () => {
+    const sequence = [
+      messageItem(0, "user", "Wildcard", {
+        any_role: true,
+        any_content: true,
+      }),
+      messageItem(1, "user", "hi"),
+      messageItem(2, "assistant", "Output"),
+    ];
+    const input = normalizeInput([
+      { role: "system", content: "Environment context" },
+      { role: "user", content: "hi" },
     ]);
     const result = matchInput(sequence, input);
 

--- a/src/lib/responses/matching.ts
+++ b/src/lib/responses/matching.ts
@@ -51,6 +51,7 @@ const StoredMessageContentSchema = z.object({
   // Wildcards are only meaningful for input (non-assistant) messages.
   any_role: z.boolean().optional(),
   any_content: z.boolean().optional(),
+  repeat: z.boolean().optional(),
 });
 
 const StoredFunctionCallContentSchema = z.object({
@@ -158,51 +159,105 @@ export function isOutputItem(item: TestItemRecord): item is OutputTestItem {
   return item.type === "message" && item.content.role === "assistant";
 }
 
+function matchSegments(
+  segments: Array<{ item: TestItemRecord; repeat: boolean }>,
+  input: NormalizedInputItem[]
+): MatchError | null {
+  return matchRecursive(segments, 0, input, 0);
+}
+
+function matchRecursive(
+  segments: Array<{ item: TestItemRecord; repeat: boolean }>,
+  segIdx: number,
+  input: NormalizedInputItem[],
+  inputIdx: number
+): MatchError | null {
+  if (segIdx >= segments.length) {
+    return inputIdx === input.length
+      ? null
+      : {
+          status: 400,
+          message: "Input extends beyond the defined test sequence",
+          type: "invalid_request_error",
+          code: "sequence_exhausted",
+        };
+  }
+
+  const { item: expected, repeat } = segments[segIdx];
+
+  if (!repeat) {
+    if (inputIdx >= input.length) {
+      return {
+        status: 400,
+        message: `Input too short: expected more items at segment ${segIdx}`,
+        type: "invalid_request_error",
+        code: "input_mismatch",
+      };
+    }
+    const mismatch = compareItems(expected, input[inputIdx], inputIdx);
+    if (mismatch) return mismatch;
+    return matchRecursive(segments, segIdx + 1, input, inputIdx + 1);
+  }
+
+  const maxConsume = input.length - inputIdx;
+  for (let count = maxConsume; count >= 1; count--) {
+    let allMatch = true;
+    for (let j = 0; j < count; j++) {
+      if (compareItems(expected, input[inputIdx + j], inputIdx + j) !== null) {
+        allMatch = false;
+        break;
+      }
+    }
+    if (!allMatch) continue;
+    const rest = matchRecursive(segments, segIdx + 1, input, inputIdx + count);
+    if (rest === null) return null;
+  }
+
+  return {
+    status: 400,
+    message: `Repeat wildcard at segment ${segIdx} could not match`,
+    type: "invalid_request_error",
+    code: "input_mismatch",
+  };
+}
+
 export function matchInput(
   sequence: TestItemRecord[],
   input: NormalizedInputItem[]
 ): MatchResult {
-  const expectedItems: TestItemRecord[] = [];
+  const segments: Array<{ item: TestItemRecord; repeat: boolean }> = [];
   let matchBoundary = -1;
 
   for (let i = 0; i < sequence.length; i++) {
     const item = sequence[i];
-
     if (isOutputItem(item)) {
-      if (expectedItems.length === input.length) {
+      const err = matchSegments(segments, input);
+      if (err === null) {
         matchBoundary = i;
         break;
       }
-      expectedItems.push(item);
+      segments.push({ item, repeat: false });
     } else {
-      expectedItems.push(item);
+      const repeat =
+        item.type === "message" &&
+        item.content.any_role === true &&
+        item.content.any_content === true &&
+        item.content.repeat === true;
+      segments.push({ item, repeat });
     }
   }
 
   if (matchBoundary === -1) {
-    if (expectedItems.length <= input.length) {
-      return {
-        status: 400,
-        message: "Input extends beyond the defined test sequence",
-        type: "invalid_request_error",
-        code: "sequence_exhausted",
-      };
+    const err = matchSegments(segments, input);
+    if (err !== null) {
+      return err;
     }
     return {
       status: 400,
-      message:
-        `Input mismatch: expected ${expectedItems.length} input items ` +
-        `but got ${input.length}`,
+      message: "Input extends beyond the defined test sequence",
       type: "invalid_request_error",
-      code: "input_mismatch",
+      code: "sequence_exhausted",
     };
-  }
-
-  for (let i = 0; i < expectedItems.length; i++) {
-    const expected = expectedItems[i];
-    const actual = input[i];
-    const mismatch = compareItems(expected, actual, i);
-    if (mismatch) return mismatch;
   }
 
   const outputItems: OutputTestItem[] = [];

--- a/src/lib/responses/types.ts
+++ b/src/lib/responses/types.ts
@@ -9,6 +9,7 @@ export interface MessageContent {
   // Wildcards are only meaningful for input (non-assistant) messages.
   any_role?: boolean;
   any_content?: boolean;
+  repeat?: boolean;
 }
 
 export interface FunctionCallContent {

--- a/src/lib/schemas/test-items.ts
+++ b/src/lib/schemas/test-items.ts
@@ -5,6 +5,7 @@ const InputMessageContentSchema = z.object({
   content: z.string(),
   any_role: z.boolean().optional(),
   any_content: z.boolean().optional(),
+  repeat: z.boolean().optional(),
 });
 
 const OutputMessageContentSchema = z.object({


### PR DESCRIPTION
## Summary
- add repeat flag to message schemas/types and propagate it through matching
- switch input matching to segment-based repeat wildcard handling
- cover repeat wildcard scenarios in matching tests

## Testing
- npm test
- npm run lint

Refs #31