### PR TITLE
fix: allow org tokens (tlo_) to list orgs via GET /api/orgs

### DIFF
--- a/e2e/auth/token-authentication.test.ts
+++ b/e2e/auth/token-authentication.test.ts
@@ -181,16 +181,17 @@ describe("token authentication", () => {
     expect(body.error).toMatchObject({ code: "not_found" });
   });
 
-  it("rejects org tokens for user-scoped operations", async () => {
+  it("allows org tokens to list their scoped org", async () => {
     const admin = await createTestUser();
     const { body: org } = await createOrg(admin, { uniqueSlug: true });
     const { body: token } = await createOrgToken(admin, org.id);
 
     const response = await tokenFetch(managementUrl("/orgs"), token.token);
 
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.error).toMatchObject({ code: "unauthorized" });
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({ id: org.id });
   });
 
   it("rejects invite acceptance with org tokens", async () => {

--- a/src/app/api/orgs/route.ts
+++ b/src/app/api/orgs/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { getAuthUser } from "@/lib/auth-helpers";
+import { getAuthUser, getAuthOrToken } from "@/lib/auth-helpers";
 import { parseRequestBody } from "@/lib/validation";
 import { conflictError } from "@/lib/errors";
 import { CreateOrgSchema } from "@/lib/schemas/orgs";
@@ -51,9 +51,29 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET() {
-  const authResult = await getAuthUser();
+  const authResult = await getAuthOrToken();
   if (!authResult.ok) return authResult.error;
-  const { userId } = authResult.value;
+  const identity = authResult.value;
+
+  if (identity.kind === "org_token") {
+    const org = await prisma.organization.findUnique({
+      where: { id: identity.orgId },
+    });
+    if (!org) return NextResponse.json([]);
+
+    return NextResponse.json([
+      {
+        id: org.id,
+        name: org.name,
+        slug: org.slug,
+        role: identity.role,
+        created_at: org.createdAt.toISOString(),
+        updated_at: org.updatedAt.toISOString(),
+      },
+    ]);
+  }
+
+  const { userId } = identity;
 
   const memberships = await prisma.orgMembership.findMany({
     where: { userId },

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -1,6 +1,6 @@
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { resolveTokenIdentity } from "@/lib/token-auth";
+import { resolveTokenIdentity, OrgTokenIdentity } from "@/lib/token-auth";
 import { unauthorizedError, forbiddenError, notFoundError } from "@/lib/errors";
 import { NextResponse } from "next/server";
 import { OrgRole } from "@prisma/client";
@@ -8,6 +8,13 @@ import { OrgRole } from "@prisma/client";
 interface AuthUser {
   userId: string;
 }
+
+interface AuthUserIdentity {
+  kind: "user";
+  userId: string;
+}
+
+type AuthOrTokenIdentity = AuthUserIdentity | OrgTokenIdentity;
 
 interface AuthWithMembership {
   userId: string;
@@ -59,6 +66,24 @@ export async function getAuthUser(): Promise<AuthResult<AuthUser>> {
   }
 
   return { ok: true, value: { userId: token.userId } };
+}
+
+export async function getAuthOrToken(): Promise<AuthResult<AuthOrTokenIdentity>> {
+  const session = await auth();
+  if (session?.user?.id) {
+    return { ok: true, value: { kind: "user", userId: session.user.id } };
+  }
+
+  const token = await resolveTokenIdentity();
+  if (!token) {
+    return { ok: false, error: unauthorizedError() };
+  }
+
+  if (token.kind === "personal_token") {
+    return { ok: true, value: { kind: "user", userId: token.userId } };
+  }
+
+  return { ok: true, value: token };
 }
 
 export async function getAuthWithMembership(


### PR DESCRIPTION
## Problem

`GET /api/orgs` returns **401 Unauthorized** when called with a valid org token (`tlo_` prefix). This breaks the Terraform provider's `testllm_organization` data source.

```
testllm api error: GET /api/orgs returned 401: {"error":{"message":"Unauthorized","type":"auth_error","code":"unauthorized"}}
```

## Root Cause

`GET /api/orgs` calls `getAuthUser()` which explicitly rejects org tokens:

```typescript
// src/lib/auth-helpers.ts — getAuthUser(), line 56
if (token.kind !== "personal_token") {
  return { ok: false, error: unauthorizedError() };  // ← org tokens hit this
}
```

This was intentional because `getAuthUser()` returns `{ userId: string }` and org tokens (`OrgApiToken`) have no `userId` — they're scoped to an `orgId` with a `role`. However, the endpoint should still work for org tokens by returning the single org the token is scoped to.

## Fix

### 1. New `getAuthOrToken()` helper (`src/lib/auth-helpers.ts`)

Returns a discriminated union that accepts all auth methods:

```typescript
type AuthOrTokenIdentity = AuthUserIdentity | OrgTokenIdentity;

// AuthUserIdentity = { kind: "user"; userId: string }     — session or personal token
// OrgTokenIdentity = { kind: "org_token"; tokenId; orgId; role }  — org token
```

### 2. Updated `GET /api/orgs` handler (`src/app/api/orgs/route.ts`)

Branches on identity kind:
- **`"user"`** (session / personal token): existing behavior — queries memberships by `userId`, returns all orgs
- **`"org_token"`**: returns a single-element array with the token's scoped org and role

### 3. Updated e2e test (`e2e/auth/token-authentication.test.ts`)

Changed `"rejects org tokens for user-scoped operations"` → `"allows org tokens to list their scoped org"` with assertions for 200 status and correct org in response.

## Files Changed

| File | Change |
|------|--------|
| `src/lib/auth-helpers.ts` | Added `AuthUserIdentity`, `AuthOrTokenIdentity` types; added `getAuthOrToken()` export; imported `OrgTokenIdentity` |
| `src/app/api/orgs/route.ts` | `GET` now uses `getAuthOrToken()` with org-token branch |
| `e2e/auth/token-authentication.test.ts` | Updated test to expect 200 with scoped org for org tokens |

## Verification

- `npx tsc --noEmit` passes with zero errors
- Existing behavior for session auth and personal tokens is unchanged
- `POST /api/orgs` still uses `getAuthUser()` (org tokens can't create orgs — correct)