### PR TITLE
fix(matching): use JSON-semantic comparison for function_call_output

### DIFF
--- a/src/lib/responses/__tests__/matching.test.ts
+++ b/src/lib/responses/__tests__/matching.test.ts
@@ -408,3 +408,85 @@ describe("matchInput", () => {
     }
   });
 });
+
+describe("function_call_output JSON-semantic comparison", () => {
+  it("matches function_call_output with reordered JSON keys", () => {
+    const sequence = [
+      messageItem(0, "user", "Create entity"),
+      functionCallItem(1, "fc_001", "create_entities", '{"entities":[{"name":"test","entityType":"project"}]}'),
+      functionCallOutputItem(2, "fc_001", '{"entities":[{"name":"test","entityType":"project"}]}'),
+      messageItem(3, "assistant", "Done"),
+    ];
+    const input = normalizeInput([
+      { role: "user", content: "Create entity" },
+      {
+        type: "function_call",
+        call_id: "fc_001",
+        name: "create_entities",
+        arguments: '{"entities":[{"name":"test","entityType":"project"}]}',
+      },
+      {
+        type: "function_call_output",
+        call_id: "fc_001",
+        // Keys in different (alphabetical) order — should still match
+        output: '{"entities":[{"entityType":"project","name":"test"}]}',
+      },
+    ]);
+    const result = matchInput(sequence, input);
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputItems).toHaveLength(1);
+      expect(result.outputItems[0].type).toBe("message");
+    }
+  });
+
+  it("still rejects function_call_output with different JSON values", () => {
+    const sequence = [
+      messageItem(0, "user", "Create entity"),
+      functionCallItem(1, "fc_001", "create_entities", "{}"),
+      functionCallOutputItem(2, "fc_001", '{"entities":[{"name":"test"}]}'),
+      messageItem(3, "assistant", "Done"),
+    ];
+    const input = normalizeInput([
+      { role: "user", content: "Create entity" },
+      {
+        type: "function_call",
+        call_id: "fc_001",
+        name: "create_entities",
+        arguments: "{}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "fc_001",
+        output: '{"entities":[{"name":"different"}]}',
+      },
+    ]);
+    const result = matchInput(sequence, input);
+    expect(isMatchError(result)).toBe(true);
+  });
+
+  it("compares non-JSON output as exact strings", () => {
+    const sequence = [
+      messageItem(0, "user", "Run tool"),
+      functionCallItem(1, "fc_001", "tool", "{}"),
+      functionCallOutputItem(2, "fc_001", "plain text output"),
+      messageItem(3, "assistant", "Done"),
+    ];
+    const input = normalizeInput([
+      { role: "user", content: "Run tool" },
+      {
+        type: "function_call",
+        call_id: "fc_001",
+        name: "tool",
+        arguments: "{}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "fc_001",
+        output: "different plain text",
+      },
+    ]);
+    const result = matchInput(sequence, input);
+    expect(isMatchError(result)).toBe(true);
+  });
+});

--- a/src/lib/responses/matching.ts
+++ b/src/lib/responses/matching.ts
@@ -293,6 +293,47 @@ export function matchInput(
   return { outputItems };
 }
 
+
+/**
+ * Compare two output strings for semantic equality.
+ * If both strings are valid JSON, compare the parsed values (ignoring key order).
+ * Otherwise, fall back to exact string comparison.
+ */
+function outputMatches(expected: string, actual: string): boolean {
+  if (expected === actual) return true;
+  try {
+    const expectedParsed: unknown = JSON.parse(expected);
+    const actualParsed: unknown = JSON.parse(actual);
+    return jsonDeepEqual(expectedParsed, actualParsed);
+  } catch {
+    return false;
+  }
+}
+
+function jsonDeepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== typeof b) return false;
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((val, i) => jsonDeepEqual(val, b[i]));
+  }
+
+  if (typeof a === "object" && typeof b === "object") {
+    const aObj = a as Record<string, unknown>;
+    const bObj = b as Record<string, unknown>;
+    const aKeys = Object.keys(aObj);
+    const bKeys = Object.keys(bObj);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(
+      (key) => key in bObj && jsonDeepEqual(aObj[key], bObj[key])
+    );
+  }
+
+  return false;
+}
+
 function compareItems(
   expected: TestItemRecord,
   actual: NormalizedInputItem,
@@ -361,7 +402,10 @@ function compareItems(
     actual.type === "function_call_output"
   ) {
     const content = expected.content;
-    if (content.call_id !== actual.call_id || content.output !== actual.output) {
+    if (
+      content.call_id !== actual.call_id ||
+      !outputMatches(content.output, actual.output)
+    ) {
       return {
         status: 400,
         message:


### PR DESCRIPTION
## Problem

The `TestMCPToolsAgnE2E` e2e test in `agents-orchestrator` fails with a 400 error when the agn-cli sends `function_call_output` back to testllm. The `output` field contains serialized JSON from MCP tool `structuredContent`, but JSON key ordering differs between runtimes:

- **Go** (`json.Marshal` on `map[string]any`): produces **alphabetically sorted** keys → `{"entities":[{"entityType":"project","name":"test_project",...}]}`
- **Rust** (`serde_json` with `preserve_order`): preserves **insertion order** → `{"entities":[{"name":"test_project","entityType":"project",...}]}`

The fixture expects insertion order (matching Codex/Rust output). testllm's `compareItems` used strict string equality (`!==`) on the `output` field, causing a mismatch for the Go agent even though the JSON values are semantically identical.

## Root Cause

Per RFC 8259, JSON object key ordering is **not semantically significant**. The strict string comparison in testllm's matching logic rejected valid, semantically equivalent JSON that happened to have different key order.

## Fix

- Added `outputMatches()` helper that:
  1. Short-circuits on exact string match (fast path)
  2. Attempts `JSON.parse` on both strings and deep-compares parsed values (ignoring key order)
  3. Falls back to `false` if either string is not valid JSON
- Added `jsonDeepEqual()` recursive comparator for JSON values (handles objects, arrays, primitives, null)
- Replaced `content.output !== actual.output` with `!outputMatches(content.output, actual.output)` in the `function_call_output` branch of `compareItems`

## Tests

Added 3 new test cases in `matching.test.ts`:
- ✅ `matches function_call_output with reordered JSON keys` — validates the fix
- ✅ `still rejects function_call_output with different JSON values` — ensures mismatches are caught
- ✅ `compares non-JSON output as exact strings` — ensures non-JSON strings still require exact match

All 23 tests pass (20 existing + 3 new).

## Related

- `agynio/agents-orchestrator` E2E test: `TestMCPToolsAgnE2E`
- `agynio/agn-cli` PR #49 (structuredContent fix): already merged
- `agynio/agent-init-agn` v0.2.6: image with agn v0.2.4 already published