### PR TITLE
feat(messages): add anthropic protocol

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -77,6 +77,7 @@ erDiagram
         uuid org_id FK
         string name
         string description
+        string protocol
         timestamp created_at
         timestamp updated_at
     }
@@ -233,12 +234,13 @@ A grouping of related tests within an organization.
 | `org_id` | UUID | FK → Organization |
 | `name` | string | Display name, unique within the organization |
 | `description` | string | Optional description |
+| `protocol` | enum | Protocol used by the suite (`openai` or `anthropic`) |
 | `created_at` | timestamp | Creation time |
 | `updated_at` | timestamp | Last modification time |
 
 ### Test
 
-A single predefined conversation. The test name is used as the `model` field in Responses API requests.
+A single predefined conversation. The test name is used as the `model` field in Responses or Messages API requests.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -251,7 +253,7 @@ A single predefined conversation. The test name is used as the `model` field in 
 
 ### TestItem
 
-A single item in a test's conversation sequence. Items are ordered by `position` and follow the OpenAI Responses API item types.
+A single item in a test's conversation sequence. Items are ordered by `position` and follow the protocol-specific item types for the parent suite.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -288,7 +290,7 @@ TestRun has no status or lifecycle fields. Duration and timing are derived from 
 
 ### ResponseLog
 
-Records a single Responses API call attributed to a test run. Created via fire-and-forget after each Responses API request on the run-tracking path.
+Records a single Responses or Messages API call attributed to a test run. Created via fire-and-forget after each tracked request.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -337,11 +339,13 @@ This design allows a single TestLLM test (conversation sequence) to be reused by
 
 ## Item Types
 
-TestItems represent items in the OpenAI Responses API format. The `type` field determines the role of the item and the structure of `content`.
+TestItems represent protocol-specific items. The `type` field determines the role of the item and the structure of `content`.
 
 Items are classified as **input items** or **output items**:
-- **Input items** — items sent by the caller to the model. The Responses API endpoint matches incoming `input` against these.
-- **Output items** — items returned by the model. The Responses API endpoint returns these when input matches.
+- **Input items** — items sent by the caller to the model. The Responses or Messages endpoint matches incoming inputs against these.
+- **Output items** — items returned by the model. The endpoint returns these when input matches.
+
+### OpenAI Responses API types
 
 ### `message` (input)
 
@@ -400,6 +404,43 @@ A function call emitted by the model.
     "call_id": "call_abc123",
     "name": "get_weather",
     "arguments": "{\"location\":\"San Francisco\",\"unit\":\"fahrenheit\"}"
+  }
+}
+```
+
+### Anthropic Messages API types
+
+Anthropic suites use two item types:
+
+- `anthropic_system` — system prompt stored as either `{ "text": "..." }` or `{ "blocks": [ ... ] }`.
+- `anthropic_message` — user or assistant messages stored with a `role` (`user` or `assistant`) and `content` as a string or array of content blocks.
+
+Content blocks follow the Anthropic Messages API format:
+
+- `text` — `{ "type": "text", "text": "..." }`
+- `tool_use` — `{ "type": "tool_use", "id": "...", "name": "...", "input": { ... } }`
+- `tool_result` — `{ "type": "tool_result", "tool_use_id": "...", "content": "..." }`
+
+```json
+{
+  "type": "anthropic_system",
+  "content": {
+    "text": "You are a weather assistant."
+  }
+}
+```
+
+```json
+{
+  "type": "anthropic_message",
+  "content": {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Weather in SF?"
+      }
+    ]
   }
 }
 ```

--- a/docs/messages-api.md
+++ b/docs/messages-api.md
@@ -1,0 +1,107 @@
+# Messages API (Anthropic-compatible)
+
+## Overview
+
+The Messages API provides an Anthropic-compatible endpoint for deterministic message replay. Each request is matched against a predefined test sequence stored in TestLLM. When inputs match, the next assistant message in the sequence is returned.
+
+## Endpoints
+
+```
+POST /v1/org/{orgSlug}/suite/{suiteName}/messages
+POST /v1/org/{orgSlug}/suite/{suiteName}/run/{runId}/test/{clientTestName}/messages
+```
+
+The run-tracking path behaves identically but records a response log for observability.
+
+## Request Format
+
+The request body mirrors the Anthropic Messages API shape. Only the fields below are required for matching; additional fields are accepted and ignored.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `model` | string | yes | Test name within the suite |
+| `max_tokens` | number | yes | Maximum tokens for the response |
+| `system` | string \| array | no | System prompt (string or content blocks) |
+| `messages` | array | yes | User/assistant message history |
+| `stream` | boolean | no | Enable SSE streaming |
+
+Message content may be a string or a list of content blocks. Supported content block types are `text`, `tool_use`, and `tool_result`.
+
+## Matching Algorithm
+
+Test suites configured with the `anthropic` protocol use two item types:
+
+- `anthropic_system`: a system prompt stored as `{ "text": "..." }` or `{ "blocks": [ ... ] }`.
+- `anthropic_message`: a message with `role` (`user` or `assistant`) and `content` (string or content blocks).
+
+Matching rules:
+
+1. Iterate the stored test items in order.
+2. `anthropic_system` items must match the request `system` prompt exactly.
+3. `anthropic_message` items with `role: user` must match the next request message.
+4. `anthropic_message` items with `role: assistant`:
+   - If the request has no remaining messages, this is the output boundary and the assistant message is returned.
+   - If the request includes a matching assistant message, matching continues (multi-turn history).
+
+If the input diverges, the request returns an error.
+
+## Response Format
+
+On success, TestLLM returns a Message object with a deterministic `id` and zeroed token usage:
+
+```json
+{
+  "id": "msg_...",
+  "type": "message",
+  "role": "assistant",
+  "model": "weather-test",
+  "content": [
+    { "type": "text", "text": "It is 65F." }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": { "input_tokens": 0, "output_tokens": 0 }
+}
+```
+
+`stop_reason` is `tool_use` whenever the response includes a `tool_use` block; otherwise it is `end_turn`.
+
+## Streaming
+
+When `stream: true`, the endpoint returns `text/event-stream` with the Anthropic event sequence:
+
+```
+message_start -> content_block_start -> content_block_delta -> content_block_stop -> message_delta -> message_stop
+```
+
+Each event payload includes a `type` field matching the event name. Text blocks emit `text_delta` updates. Tool-use blocks emit `input_json_delta` updates containing the serialized tool input.
+
+## Error Handling
+
+Errors return Anthropic-style payloads:
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "invalid_request_error",
+    "message": "Missing required field: model"
+  }
+}
+```
+
+Error types and status codes:
+
+| Condition | Status | Error Type | Example Message |
+|-----------|--------|------------|-----------------|
+| Organization not found | 404 | `not_found_error` | `Organization '{orgSlug}' not found` |
+| Suite not found | 404 | `not_found_error` | `Test suite '{suiteName}' not found in organization '{orgSlug}'` |
+| Model not found | 404 | `not_found_error` | `Model '{model}' not found in suite '{suiteName}'` |
+| Invalid JSON | 400 | `invalid_request_error` | `Invalid JSON body` |
+| Missing required field | 400 | `invalid_request_error` | `Missing required field: model` |
+| Input mismatch | 400 | `invalid_request_error` | `Input mismatch at position 2: expected role 'user', got 'assistant'` |
+| Sequence exhausted | 400 | `invalid_request_error` | `Input extends beyond the defined test sequence` |
+
+## Run Tracking
+
+The run-tracking endpoint (`/run/{runId}/test/{clientTestName}/messages`) records a response log for every call. Logs include the input payload, output payload, timing, and error metadata, and can be inspected via the Management API.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TestLLM is a deterministic LLM service for end-to-end testing of AI agents. It exposes an OpenAI-compatible Responses API backed by predefined conversation sequences. Instead of calling a real LLM, test infrastructure points agents at TestLLM, which replays scripted responses — making agent behavior fully deterministic and assertable.
+TestLLM is a deterministic LLM service for end-to-end testing of AI agents. It exposes OpenAI-compatible Responses API and Anthropic Messages API protocols backed by predefined conversation sequences. Instead of calling a real LLM, test infrastructure points agents at TestLLM, which replays scripted responses — making agent behavior fully deterministic and assertable.
 
 ## Problem
 
@@ -12,11 +12,11 @@ Agents depend on LLM responses for decision-making, tool calling, and message ge
 
 TestLLM acts as an LLM provider. The test creates an LLM Provider resource in the platform pointing at the TestLLM endpoint and a Model resource referencing a predefined test (conversation). The agent uses the standard LLM service proxy path and hits TestLLM instead of a real provider.
 
-A **test** is an ordered sequence of items following the OpenAI Responses API format — input messages, output messages, function calls, and function call outputs. Each Responses API request is matched against the test sequence by comparing the incoming `input` items with the expected prefix. On exact match, the service returns the next output items from the sequence. On mismatch, it returns an error.
+A **test** is an ordered sequence of items following the protocol configured for its test suite (OpenAI Responses or Anthropic Messages). Each request is matched against the test sequence by comparing incoming inputs with the expected prefix. On exact match, the service returns the next output items from the sequence. On mismatch, it returns an error.
 
 This makes LLM interactions fully deterministic: the agent receives the exact scripted responses, makes the exact scripted tool calls, and produces the exact expected behavior — testable with standard assertions.
 
-For observability, TestLLM supports **test run tracking**. A test run groups all Responses API calls from a single CI execution. Each call is recorded as a response log with full request/response data, timing, and pass/fail status. The Management API and UI provide run summaries, per-test-execution breakdowns, and detailed log inspection — giving visibility into exactly what happened during each test execution.
+For observability, TestLLM supports **test run tracking**. A test run groups all Responses or Messages API calls from a single CI execution. Each call is recorded as a response log with full request/response data, timing, and pass/fail status. The Management API and UI provide run summaries, per-test-execution breakdowns, and detailed log inspection — giving visibility into exactly what happened during each test execution.
 
 ```mermaid
 sequenceDiagram
@@ -64,9 +64,9 @@ Organization
 
 - **Organization** — top-level tenant. Users are invited to organizations.
 - **Test Suite** — a grouping of related tests within an organization.
-- **Test** — a single predefined conversation (ordered sequence of Responses API items). The test name is used as the model identifier in Responses API requests. Test names are unique within a test suite.
-- **Test Run** — a container for a single CI/test execution. Groups all Responses API calls made during one run. Created lazily on the first tracked API call. The run ID is client-generated (UUID).
-- **Response Log** — a record of a single Responses API call within a test run. Captures input, output (or error), timing, and resolution metadata.
+- **Test** — a single predefined conversation (ordered sequence of protocol-specific items). The test name is used as the model identifier in Responses or Messages API requests. Test names are unique within a test suite.
+- **Test Run** — a container for a single CI/test execution. Groups all Responses or Messages API calls made during one run. Created lazily on the first tracked API call. The run ID is client-generated (UUID).
+- **Response Log** — a record of a single Responses or Messages API call within a test run. Captures input, output (or error), timing, and resolution metadata.
 
 ## Documentation
 
@@ -74,5 +74,6 @@ Organization
 |----------|-------------|
 | [Data Model](data-model.md) | Database entities, relationships, item types |
 | [Responses API](responses-api.md) | OpenAI-compatible endpoint — request matching, response generation, error handling, run tracking |
+| [Messages API](messages-api.md) | Anthropic-compatible endpoint — request matching, response generation, error handling, run tracking |
 | [Management API](management-api.md) | CRUD operations for organizations, test suites, tests, user management, and test runs |
 | [Authentication](authentication.md) | OIDC for management UI/API, no auth for Responses API |

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -31,6 +31,23 @@ export function responsesRunUrl(
   );
 }
 
+export function messagesUrl(orgSlug: string, suiteName: string) {
+  return apiUrl(`/v1/org/${orgSlug}/suite/${suiteName}/messages`);
+}
+
+export function messagesRunUrl(
+  orgSlug: string,
+  suiteName: string,
+  runId: string,
+  clientTestName: string
+) {
+  return apiUrl(
+    `/v1/org/${orgSlug}/suite/${suiteName}/run/${runId}/test/${encodeURIComponent(
+      clientTestName
+    )}/messages`
+  );
+}
+
 export function jsonRequest(body: unknown): RequestInit {
   return {
     headers: {

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -153,6 +153,79 @@ export const multiOutputSequence: TestItemFixture[] = [
   },
 ];
 
+export const anthropicSimpleSequence: TestItemFixture[] = [
+  {
+    type: "anthropic_system",
+    content: {
+      text: "You are helpful.",
+    },
+  },
+  {
+    type: "anthropic_message",
+    content: {
+      role: "user",
+      content: "Hello there",
+    },
+  },
+  {
+    type: "anthropic_message",
+    content: {
+      role: "assistant",
+      content: [{ type: "text", text: "Hi! How can I help?" }],
+    },
+  },
+];
+
+export const anthropicToolSequence: TestItemFixture[] = [
+  {
+    type: "anthropic_system",
+    content: {
+      text: "You are a weather assistant.",
+    },
+  },
+  {
+    type: "anthropic_message",
+    content: {
+      role: "user",
+      content: [{ type: "text", text: "Weather in SF?" }],
+    },
+  },
+  {
+    type: "anthropic_message",
+    content: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_01",
+          name: "get_weather",
+          input: { city: "SF" },
+        },
+      ],
+    },
+  },
+  {
+    type: "anthropic_message",
+    content: {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_01",
+          content: "65F",
+        },
+      ],
+    },
+  },
+  {
+    type: "anthropic_message",
+    content: {
+      role: "assistant",
+      content: [{ type: "text", text: "It is 65F." }],
+    },
+  },
+];
+
 export function withPositions<T extends TestItemFixture>(
   items: ReadonlyArray<T>
 ) {

--- a/e2e/messages/messages-api.test.ts
+++ b/e2e/messages/messages-api.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "crypto";
+import { setTimeout as delay } from "timers/promises";
+import { jsonRequest, messagesRunUrl, messagesUrl } from "../helpers/api";
+import { prisma } from "../helpers/prisma";
+import {
+  anthropicSimpleSequence,
+  anthropicToolSequence,
+  TestItemFixture,
+  withPositions,
+} from "../helpers/fixtures";
+
+async function readSseEvents(response: Response) {
+  const text = await response.text();
+
+  return text
+    .trim()
+    .split("\n\n")
+    .filter(Boolean)
+    .map((chunk) => {
+      const lines = chunk.split("\n");
+      const eventLine = lines.find((line) => line.startsWith("event: "));
+      const dataLine = lines.find((line) => line.startsWith("data: "));
+
+      if (!eventLine || !dataLine) {
+        throw new Error("Invalid SSE frame");
+      }
+
+      return {
+        event: eventLine.slice("event: ".length),
+        data: JSON.parse(dataLine.slice("data: ".length)),
+      };
+    });
+}
+
+async function seedMessageTest({
+  orgSlug = "acme",
+  suiteName = "messages",
+  testName = "simple",
+  items = anthropicSimpleSequence,
+}: {
+  orgSlug?: string;
+  suiteName?: string;
+  testName?: string;
+  items?: ReadonlyArray<TestItemFixture>;
+}) {
+  const org = await prisma.organization.create({
+    data: { name: "Acme", slug: orgSlug },
+  });
+  const suite = await prisma.testSuite.create({
+    data: { orgId: org.id, name: suiteName, protocol: "anthropic" },
+  });
+  const test = await prisma.test.create({
+    data: { testSuiteId: suite.id, name: testName },
+  });
+
+  await prisma.testItem.createMany({
+    data: withPositions(items).map((item) => ({
+      ...item,
+      testId: test.id,
+    })),
+  });
+
+  return { org, suite, test };
+}
+
+async function waitForResponseLogs(runId: string, expectedCount: number) {
+  const deadline = Date.now() + 5000;
+
+  while (Date.now() < deadline) {
+    const count = await prisma.responseLog.count({ where: { runId } });
+    if (count >= expectedCount) return;
+    await delay(50);
+  }
+
+  throw new Error("Timed out waiting for response logs");
+}
+
+describe("messages api", () => {
+  it("returns org_not_found when org is missing", async () => {
+    const response = await fetch(messagesUrl("missing", "suite"), {
+      method: "POST",
+      ...jsonRequest({
+        model: "test",
+        max_tokens: 10,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toMatchObject({ type: "not_found_error" });
+  });
+
+  it("returns suite_not_found when suite is missing", async () => {
+    const org = await prisma.organization.create({
+      data: { name: "Acme", slug: "acme" },
+    });
+
+    const response = await fetch(messagesUrl(org.slug, "missing"), {
+      method: "POST",
+      ...jsonRequest({
+        model: "test",
+        max_tokens: 10,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toMatchObject({ type: "not_found_error" });
+  });
+
+  it("returns model_not_found when test is missing", async () => {
+    const org = await prisma.organization.create({
+      data: { name: "Acme", slug: "acme" },
+    });
+    const suite = await prisma.testSuite.create({
+      data: { orgId: org.id, name: "default", protocol: "anthropic" },
+    });
+
+    const response = await fetch(messagesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: "missing",
+        max_tokens: 10,
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toMatchObject({ type: "not_found_error" });
+  });
+
+  it("returns invalid_request_error for malformed JSON", async () => {
+    const response = await fetch(messagesUrl("acme", "default"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not-json}",
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatchObject({ type: "invalid_request_error" });
+  });
+
+  it("returns missing field errors", async () => {
+    const missingModel = await fetch(messagesUrl("acme", "default"), {
+      method: "POST",
+      ...jsonRequest({ max_tokens: 10, messages: [] }),
+    });
+    expect(missingModel.status).toBe(400);
+
+    const missingMaxTokens = await fetch(messagesUrl("acme", "default"), {
+      method: "POST",
+      ...jsonRequest({ model: "test", messages: [] }),
+    });
+    expect(missingMaxTokens.status).toBe(400);
+
+    const missingMessages = await fetch(messagesUrl("acme", "default"), {
+      method: "POST",
+      ...jsonRequest({ model: "test", max_tokens: 10 }),
+    });
+    expect(missingMessages.status).toBe(400);
+  });
+
+  it("matches a simple message and returns Anthropic format", async () => {
+    const { org, suite, test } = await seedMessageTest({});
+
+    const response = await fetch(messagesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: test.name,
+        max_tokens: 10,
+        system: "You are helpful.",
+        messages: [{ role: "user", content: "Hello there" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      type: "message",
+      role: "assistant",
+      model: test.name,
+      stop_reason: "end_turn",
+    });
+    expect(body.content[0]).toMatchObject({ type: "text" });
+  });
+
+  it("supports multi-turn tool use", async () => {
+    const { org, suite, test } = await seedMessageTest({
+      items: anthropicToolSequence,
+      testName: "tool-flow",
+    });
+
+    const firstResponse = await fetch(messagesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: test.name,
+        max_tokens: 10,
+        system: "You are a weather assistant.",
+        messages: [{ role: "user", content: "Weather in SF?" }],
+      }),
+    });
+
+    expect(firstResponse.status).toBe(200);
+    const firstBody = await firstResponse.json();
+    expect(firstBody.stop_reason).toBe("tool_use");
+    expect(firstBody.content[0]).toMatchObject({ type: "tool_use" });
+
+    const secondResponse = await fetch(messagesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: test.name,
+        max_tokens: 10,
+        system: "You are a weather assistant.",
+        messages: [
+          { role: "user", content: "Weather in SF?" },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_01",
+                name: "get_weather",
+                input: { city: "SF" },
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "toolu_01",
+                content: "65F",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(secondResponse.status).toBe(200);
+    const secondBody = await secondResponse.json();
+    expect(secondBody.stop_reason).toBe("end_turn");
+    expect(secondBody.content[0]).toMatchObject({ type: "text" });
+  });
+
+  it("streams messages as SSE", async () => {
+    const { org, suite, test } = await seedMessageTest({});
+
+    const response = await fetch(messagesUrl(org.slug, suite.name), {
+      method: "POST",
+      ...jsonRequest({
+        model: test.name,
+        max_tokens: 10,
+        stream: true,
+        system: "You are helpful.",
+        messages: [{ role: "user", content: "Hello there" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain(
+      "text/event-stream"
+    );
+
+    const events = await readSseEvents(response);
+    expect(events.map((event) => event.event)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+
+    events.forEach(({ event, data }) => {
+      expect(data.type).toBe(event);
+    });
+  });
+
+  it("records response logs for run tracking", async () => {
+    const { org, suite, test } = await seedMessageTest({
+      testName: "run-test",
+    });
+    const runId = randomUUID();
+
+    const response = await fetch(
+      messagesRunUrl(org.slug, suite.name, runId, "client-run"),
+      {
+        method: "POST",
+        ...jsonRequest({
+          model: test.name,
+          max_tokens: 10,
+          system: "You are helpful.",
+          messages: [{ role: "user", content: "Hello there" }],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    await waitForResponseLogs(runId, 1);
+
+    const log = await prisma.responseLog.findFirst({ where: { runId } });
+    expect(log).toBeTruthy();
+    expect(log?.status).toBe("success");
+  });
+});

--- a/prisma/migrations/20260410222848_add_protocol_and_anthropic_items/migration.sql
+++ b/prisma/migrations/20260410222848_add_protocol_and_anthropic_items/migration.sql
@@ -1,0 +1,16 @@
+-- CreateEnum
+CREATE TYPE "Protocol" AS ENUM ('openai', 'anthropic');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "TestItemType" ADD VALUE 'anthropic_system';
+ALTER TYPE "TestItemType" ADD VALUE 'anthropic_message';
+
+-- AlterTable
+ALTER TABLE "test_suites" ADD COLUMN     "protocol" "Protocol" NOT NULL DEFAULT 'openai';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,13 @@ enum TestItemType {
   message
   function_call
   function_call_output
+  anthropic_system
+  anthropic_message
+}
+
+enum Protocol {
+  openai
+  anthropic
 }
 
 enum ResponseLogStatus {
@@ -117,6 +124,7 @@ model TestSuite {
   orgId       String   @map("org_id") @db.Uuid
   name        String
   description String?
+  protocol    Protocol @default(openai)
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 

--- a/src/app/api/orgs/[orgId]/suites/[suiteId]/route.ts
+++ b/src/app/api/orgs/[orgId]/suites/[suiteId]/route.ts
@@ -26,6 +26,7 @@ export async function GET(
     org_id: suite.orgId,
     name: suite.name,
     description: suite.description,
+    protocol: suite.protocol,
     created_at: suite.createdAt.toISOString(),
     updated_at: suite.updatedAt.toISOString(),
   });
@@ -71,6 +72,7 @@ export async function PATCH(
     org_id: suite.orgId,
     name: suite.name,
     description: suite.description,
+    protocol: suite.protocol,
     created_at: suite.createdAt.toISOString(),
     updated_at: suite.updatedAt.toISOString(),
   });

--- a/src/app/api/orgs/[orgId]/suites/[suiteId]/tests/[testId]/route.ts
+++ b/src/app/api/orgs/[orgId]/suites/[suiteId]/tests/[testId]/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { getAuthWithMembership } from "@/lib/auth-helpers";
 import { parseRequestBody } from "@/lib/validation";
 import { conflictError, notFoundError } from "@/lib/errors";
-import { UpdateTestSchema } from "@/lib/schemas/test-items";
+import {
+  UpdateAnthropicTestSchema,
+  UpdateTestSchema,
+} from "@/lib/schemas/test-items";
 import { findTestOrNull, formatTestResponse } from "@/lib/test-helpers";
+
+type UpdateTestPayload =
+  | z.infer<typeof UpdateTestSchema>
+  | z.infer<typeof UpdateAnthropicTestSchema>;
 
 export async function GET(
   request: NextRequest,
@@ -38,7 +47,11 @@ export async function PATCH(
   const test = await findTestOrNull(orgId, suiteId, testId);
   if (!test) return notFoundError("Test");
 
-  const parsed = await parseRequestBody(request, UpdateTestSchema);
+  const schema: z.ZodType<UpdateTestPayload> =
+    test.testSuite.protocol === "anthropic"
+      ? UpdateAnthropicTestSchema
+      : UpdateTestSchema;
+  const parsed = await parseRequestBody<UpdateTestPayload>(request, schema);
   if (!parsed.ok) return parsed.error;
 
   const { name, description, items } = parsed.data;
@@ -68,7 +81,7 @@ export async function PATCH(
             create: items.map((item, index) => ({
               position: index,
               type: item.type,
-              content: item.content,
+              content: item.content as Prisma.InputJsonValue,
             })),
           },
         },

--- a/src/app/api/orgs/[orgId]/suites/[suiteId]/tests/route.ts
+++ b/src/app/api/orgs/[orgId]/suites/[suiteId]/tests/route.ts
@@ -1,11 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { getAuthWithMembership } from "@/lib/auth-helpers";
 import { parseRequestBody } from "@/lib/validation";
 import { conflictError, notFoundError } from "@/lib/errors";
-import { CreateTestSchema } from "@/lib/schemas/test-items";
+import {
+  CreateAnthropicTestSchema,
+  CreateTestSchema,
+} from "@/lib/schemas/test-items";
 import { findSuiteOrNull, formatTestResponse } from "@/lib/test-helpers";
+
+type CreateTestPayload =
+  | z.infer<typeof CreateTestSchema>
+  | z.infer<typeof CreateAnthropicTestSchema>;
 
 export async function POST(
   request: NextRequest,
@@ -19,7 +27,11 @@ export async function POST(
   const suite = await findSuiteOrNull(orgId, suiteId);
   if (!suite) return notFoundError("Test suite");
 
-  const parsed = await parseRequestBody(request, CreateTestSchema);
+  const schema: z.ZodType<CreateTestPayload> =
+    suite.protocol === "anthropic"
+      ? CreateAnthropicTestSchema
+      : CreateTestSchema;
+  const parsed = await parseRequestBody<CreateTestPayload>(request, schema);
   if (!parsed.ok) return parsed.error;
   const { name, description, items } = parsed.data;
 
@@ -33,7 +45,7 @@ export async function POST(
           create: items.map((item, index) => ({
             position: index,
             type: item.type,
-            content: item.content,
+            content: item.content as Prisma.InputJsonValue,
           })),
         },
       },

--- a/src/app/api/orgs/[orgId]/suites/route.ts
+++ b/src/app/api/orgs/[orgId]/suites/route.ts
@@ -17,11 +17,11 @@ export async function POST(
 
   const parsed = await parseRequestBody(request, CreateSuiteSchema);
   if (!parsed.ok) return parsed.error;
-  const { name, description } = parsed.data;
+  const { name, description, protocol } = parsed.data;
 
   try {
     const suite = await prisma.testSuite.create({
-      data: { orgId, name, description },
+      data: { orgId, name, description, protocol },
     });
 
     return NextResponse.json(
@@ -30,6 +30,7 @@ export async function POST(
         org_id: suite.orgId,
         name: suite.name,
         description: suite.description,
+        protocol: suite.protocol,
         created_at: suite.createdAt.toISOString(),
         updated_at: suite.updatedAt.toISOString(),
       },
@@ -67,6 +68,7 @@ export async function GET(
       org_id: suite.orgId,
       name: suite.name,
       description: suite.description,
+      protocol: suite.protocol,
       created_at: suite.createdAt.toISOString(),
       updated_at: suite.updatedAt.toISOString(),
     }))

--- a/src/app/v1/org/[orgSlug]/suite/[suiteName]/messages/route.ts
+++ b/src/app/v1/org/[orgSlug]/suite/[suiteName]/messages/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createMessageMetadata,
+  formatResponse,
+  formatSSEStream,
+} from "@/lib/messages/formatting";
+import { parseMessagesRequestBody } from "@/lib/messages/request";
+import { resolveMessageMatch } from "@/lib/messages/resolve";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgSlug: string; suiteName: string }> }
+) {
+  const { orgSlug, suiteName } = await params;
+
+  const parsedRequest = await parseMessagesRequestBody(request);
+  if (!parsedRequest.ok) return parsedRequest.error;
+
+  const { model, system, messages, stream } = parsedRequest.data;
+  const matchResult = await resolveMessageMatch({
+    orgSlug,
+    suiteName,
+    model,
+    system,
+    messages,
+  });
+  if (!matchResult.ok) return matchResult.response;
+
+  const metadata = createMessageMetadata();
+
+  if (stream) {
+    const streamBody = formatSSEStream(
+      model,
+      matchResult.outputMessage,
+      metadata
+    );
+    return new Response(streamBody, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      },
+    });
+  }
+
+  const response = formatResponse(
+    model,
+    matchResult.outputMessage,
+    metadata
+  );
+  return NextResponse.json(response);
+}

--- a/src/app/v1/org/[orgSlug]/suite/[suiteName]/run/[runId]/test/[clientTestName]/messages/route.ts
+++ b/src/app/v1/org/[orgSlug]/suite/[suiteName]/run/[runId]/test/[clientTestName]/messages/route.ts
@@ -1,0 +1,226 @@
+import { NextRequest } from "next/server";
+import { Prisma, ResponseLogStatus } from "@prisma/client";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { anthropicError } from "@/lib/errors";
+import {
+  createMessageMetadata,
+  formatResponse,
+  formatSSEStream,
+} from "@/lib/messages/formatting";
+import { parseMessagesRequestBody } from "@/lib/messages/request";
+import { resolveMessageMatch } from "@/lib/messages/resolve";
+
+const RunIdSchema = z.string().uuid();
+const ClientTestNameSchema = z.string().min(1);
+
+type RunParams = {
+  runId: string;
+  clientTestName: string;
+};
+
+type RunParamParseResult =
+  | { ok: true; data: RunParams }
+  | { ok: false; error: Response };
+
+function parseRunParams(runId: string, clientTestName: string): RunParamParseResult {
+  const runIdResult = RunIdSchema.safeParse(runId);
+  if (!runIdResult.success) {
+    return {
+      ok: false,
+      error: anthropicError(
+        400,
+        "runId must be a valid UUID",
+        "invalid_request_error"
+      ),
+    };
+  }
+
+  let decodedName: string;
+  try {
+    decodedName = decodeURIComponent(clientTestName);
+  } catch {
+    return {
+      ok: false,
+      error: anthropicError(
+        400,
+        "clientTestName must be URL encoded",
+        "invalid_request_error"
+      ),
+    };
+  }
+
+  const trimmedName = decodedName.trim();
+  const nameResult = ClientTestNameSchema.safeParse(trimmedName);
+  if (!nameResult.success) {
+    return {
+      ok: false,
+      error: anthropicError(
+        400,
+        "clientTestName must be provided",
+        "invalid_request_error"
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    data: { runId: runIdResult.data, clientTestName: trimmedName },
+  };
+}
+
+async function ensureTestRun(runId: string, orgId: string) {
+  try {
+    const run = await prisma.testRun.create({
+      data: { id: runId, orgId },
+    });
+    return { ok: true as const, run };
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      const run = await prisma.testRun.findUnique({ where: { id: runId } });
+      if (run && run.orgId === orgId) {
+        return { ok: true as const, run };
+      }
+      return {
+        ok: false as const,
+        error: anthropicError(
+          404,
+          `Test run '${runId}' not found`,
+          "not_found_error"
+        ),
+      };
+    }
+    throw error;
+  }
+}
+
+function recordResponseLog(
+  data: Prisma.ResponseLogCreateInput | Prisma.ResponseLogUncheckedCreateInput
+) {
+  void prisma.responseLog
+    .create({ data })
+    .catch((error) => console.error("Failed to record response log", error));
+}
+
+export async function POST(
+  request: NextRequest,
+  {
+    params,
+  }: {
+    params: Promise<{
+      orgSlug: string;
+      suiteName: string;
+      runId: string;
+      clientTestName: string;
+    }>;
+  }
+) {
+  const { orgSlug, suiteName, runId, clientTestName } = await params;
+
+  const runParams = parseRunParams(runId, clientTestName);
+  if (!runParams.ok) return runParams.error;
+
+  const parsedRequest = await parseMessagesRequestBody(request);
+  if (!parsedRequest.ok) return parsedRequest.error;
+
+  const { model, system, messages, max_tokens, stream } = parsedRequest.data;
+  const streamEnabled = stream === true;
+
+  const org = await prisma.organization.findUnique({
+    where: { slug: orgSlug },
+  });
+  if (!org) {
+    return anthropicError(
+      404,
+      `Organization '${orgSlug}' not found`,
+      "not_found_error"
+    );
+  }
+
+  const runResult = await ensureTestRun(runParams.data.runId, org.id);
+  if (!runResult.ok) return runResult.error;
+
+  const startedAt = Date.now();
+  const matchResult = await resolveMessageMatch({
+    orgSlug,
+    suiteName,
+    model,
+    system,
+    messages,
+    org,
+  });
+  const durationMs = Date.now() - startedAt;
+
+  const inputPayload = {
+    system: system ?? null,
+    messages,
+    max_tokens,
+  } as Prisma.InputJsonValue;
+
+  if (!matchResult.ok) {
+    recordResponseLog({
+      runId: runParams.data.runId,
+      status: ResponseLogStatus.error,
+      orgSlug,
+      suiteName,
+      model,
+      clientTestName: runParams.data.clientTestName,
+      input: inputPayload,
+      stream: streamEnabled,
+      suiteId: matchResult.suite?.id ?? null,
+      testId: matchResult.test?.id ?? null,
+      responseId: null,
+      errorCode: matchResult.error.code,
+      errorMessage: matchResult.error.message,
+      durationMs,
+    });
+    return matchResult.response;
+  }
+
+  const metadata = createMessageMetadata();
+  const responsePayload = formatResponse(
+    model,
+    matchResult.outputMessage,
+    metadata
+  );
+  const outputPayload: Prisma.InputJsonValue = responsePayload;
+
+  recordResponseLog({
+    runId: runParams.data.runId,
+    status: ResponseLogStatus.success,
+    orgSlug,
+    suiteName,
+    model,
+    clientTestName: runParams.data.clientTestName,
+    input: inputPayload,
+    stream: streamEnabled,
+    suiteId: matchResult.suite.id,
+    testId: matchResult.test.id,
+    output: outputPayload,
+    responseId: responsePayload.id,
+    errorCode: null,
+    errorMessage: null,
+    durationMs,
+  });
+
+  if (streamEnabled) {
+    const streamBody = formatSSEStream(
+      model,
+      matchResult.outputMessage,
+      metadata
+    );
+    return new Response(streamBody, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      },
+    });
+  }
+
+  return new Response(JSON.stringify(responsePayload), {
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/app/v1/org/[orgSlug]/suite/[suiteName]/run/[runId]/test/[clientTestName]/messages/route.ts
+++ b/src/app/v1/org/[orgSlug]/suite/[suiteName]/run/[runId]/test/[clientTestName]/messages/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest } from "next/server";
 import { Prisma, ResponseLogStatus } from "@prisma/client";
-import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { anthropicError } from "@/lib/errors";
 import {
@@ -10,100 +9,27 @@ import {
 } from "@/lib/messages/formatting";
 import { parseMessagesRequestBody } from "@/lib/messages/request";
 import { resolveMessageMatch } from "@/lib/messages/resolve";
+import {
+  ensureTestRun,
+  parseRunParams,
+  recordResponseLog,
+} from "@/lib/run-tracking";
 
-const RunIdSchema = z.string().uuid();
-const ClientTestNameSchema = z.string().min(1);
-
-type RunParams = {
-  runId: string;
-  clientTestName: string;
+const runErrorCodes = {
+  invalidRunId: "invalid_run_id",
+  invalidClientTestName: "invalid_client_test_name",
+  runNotFound: "run_not_found",
 };
 
-type RunParamParseResult =
-  | { ok: true; data: RunParams }
-  | { ok: false; error: Response };
-
-function parseRunParams(runId: string, clientTestName: string): RunParamParseResult {
-  const runIdResult = RunIdSchema.safeParse(runId);
-  if (!runIdResult.success) {
-    return {
-      ok: false,
-      error: anthropicError(
-        400,
-        "runId must be a valid UUID",
-        "invalid_request_error"
-      ),
-    };
-  }
-
-  let decodedName: string;
-  try {
-    decodedName = decodeURIComponent(clientTestName);
-  } catch {
-    return {
-      ok: false,
-      error: anthropicError(
-        400,
-        "clientTestName must be URL encoded",
-        "invalid_request_error"
-      ),
-    };
-  }
-
-  const trimmedName = decodedName.trim();
-  const nameResult = ClientTestNameSchema.safeParse(trimmedName);
-  if (!nameResult.success) {
-    return {
-      ok: false,
-      error: anthropicError(
-        400,
-        "clientTestName must be provided",
-        "invalid_request_error"
-      ),
-    };
-  }
-
-  return {
-    ok: true,
-    data: { runId: runIdResult.data, clientTestName: trimmedName },
-  };
-}
-
-async function ensureTestRun(runId: string, orgId: string) {
-  try {
-    const run = await prisma.testRun.create({
-      data: { id: runId, orgId },
-    });
-    return { ok: true as const, run };
-  } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === "P2002"
-    ) {
-      const run = await prisma.testRun.findUnique({ where: { id: runId } });
-      if (run && run.orgId === orgId) {
-        return { ok: true as const, run };
-      }
-      return {
-        ok: false as const,
-        error: anthropicError(
-          404,
-          `Test run '${runId}' not found`,
-          "not_found_error"
-        ),
-      };
-    }
-    throw error;
-  }
-}
-
-function recordResponseLog(
-  data: Prisma.ResponseLogCreateInput | Prisma.ResponseLogUncheckedCreateInput
-) {
-  void prisma.responseLog
-    .create({ data })
-    .catch((error) => console.error("Failed to record response log", error));
-}
+const formatRunError = (
+  status: number,
+  message: string,
+  type: string,
+  _code: string
+) => {
+  void _code;
+  return anthropicError(status, message, type);
+};
 
 export async function POST(
   request: NextRequest,
@@ -120,7 +46,12 @@ export async function POST(
 ) {
   const { orgSlug, suiteName, runId, clientTestName } = await params;
 
-  const runParams = parseRunParams(runId, clientTestName);
+  const runParams = parseRunParams(
+    runId,
+    clientTestName,
+    formatRunError,
+    runErrorCodes
+  );
   if (!runParams.ok) return runParams.error;
 
   const parsedRequest = await parseMessagesRequestBody(request);
@@ -140,7 +71,12 @@ export async function POST(
     );
   }
 
-  const runResult = await ensureTestRun(runParams.data.runId, org.id);
+  const runResult = await ensureTestRun(
+    runParams.data.runId,
+    org.id,
+    formatRunError,
+    runErrorCodes
+  );
   if (!runResult.ok) return runResult.error;
 
   const startedAt = Date.now();

--- a/src/app/v1/org/[orgSlug]/suite/[suiteName]/run/[runId]/test/[clientTestName]/responses/route.ts
+++ b/src/app/v1/org/[orgSlug]/suite/[suiteName]/run/[runId]/test/[clientTestName]/responses/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma, ResponseLogStatus } from "@prisma/client";
-import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { openaiError } from "@/lib/errors";
 import {
@@ -10,104 +9,24 @@ import {
 } from "@/lib/responses/formatting";
 import { parseResponsesRequestBody } from "@/lib/responses/request";
 import { resolveResponseMatch } from "@/lib/responses/resolve";
+import {
+  ensureTestRun,
+  parseRunParams,
+  recordResponseLog,
+} from "@/lib/run-tracking";
 
-const RunIdSchema = z.string().uuid();
-const ClientTestNameSchema = z.string().min(1);
-
-type RunParams = {
-  runId: string;
-  clientTestName: string;
+const runErrorCodes = {
+  invalidRunId: "invalid_run_id",
+  invalidClientTestName: "invalid_client_test_name",
+  runNotFound: "run_not_found",
 };
 
-type RunParamParseResult =
-  | { ok: true; data: RunParams }
-  | { ok: false; error: NextResponse };
-
-function parseRunParams(runId: string, clientTestName: string): RunParamParseResult {
-  const runIdResult = RunIdSchema.safeParse(runId);
-  if (!runIdResult.success) {
-    return {
-      ok: false,
-      error: openaiError(
-        400,
-        "runId must be a valid UUID",
-        "invalid_request_error",
-        "invalid_run_id"
-      ),
-    };
-  }
-
-  let decodedName: string;
-  try {
-    decodedName = decodeURIComponent(clientTestName);
-  } catch {
-    return {
-      ok: false,
-      error: openaiError(
-        400,
-        "clientTestName must be URL encoded",
-        "invalid_request_error",
-        "invalid_client_test_name"
-      ),
-    };
-  }
-
-  const trimmedName = decodedName.trim();
-  const nameResult = ClientTestNameSchema.safeParse(trimmedName);
-  if (!nameResult.success) {
-    return {
-      ok: false,
-      error: openaiError(
-        400,
-        "clientTestName must be provided",
-        "invalid_request_error",
-        "invalid_client_test_name"
-      ),
-    };
-  }
-
-  return {
-    ok: true,
-    data: { runId: runIdResult.data, clientTestName: trimmedName },
-  };
-}
-
-async function ensureTestRun(runId: string, orgId: string) {
-  try {
-    const run = await prisma.testRun.create({
-      data: { id: runId, orgId },
-    });
-    return { ok: true as const, run };
-  } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === "P2002"
-    ) {
-      const run = await prisma.testRun.findUnique({ where: { id: runId } });
-      if (run && run.orgId === orgId) {
-        return { ok: true as const, run };
-      }
-      return {
-        ok: false as const,
-        error: openaiError(
-          404,
-          `Test run '${runId}' not found`,
-          "not_found_error",
-          "run_not_found"
-        ),
-      };
-    }
-    throw error;
-  }
-}
-
-function recordResponseLog(
-  data: Prisma.ResponseLogCreateInput | Prisma.ResponseLogUncheckedCreateInput
-) {
-  void prisma.responseLog
-    .create({ data })
-    .catch((error) => console.error("Failed to record response log", error));
-}
+const formatRunError = (
+  status: number,
+  message: string,
+  type: string,
+  code: string
+) => openaiError(status, message, type, code);
 
 export async function POST(
   request: NextRequest,
@@ -124,7 +43,12 @@ export async function POST(
 ) {
   const { orgSlug, suiteName, runId, clientTestName } = await params;
 
-  const runParams = parseRunParams(runId, clientTestName);
+  const runParams = parseRunParams(
+    runId,
+    clientTestName,
+    formatRunError,
+    runErrorCodes
+  );
   if (!runParams.ok) return runParams.error;
 
   const parsedRequest = await parseResponsesRequestBody(request);
@@ -145,7 +69,12 @@ export async function POST(
     );
   }
 
-  const runResult = await ensureTestRun(runParams.data.runId, org.id);
+  const runResult = await ensureTestRun(
+    runParams.data.runId,
+    org.id,
+    formatRunError,
+    runErrorCodes
+  );
   if (!runResult.ok) return runResult.error;
 
   const startedAt = Date.now();

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -62,3 +62,16 @@ export function openaiError(
 ): NextResponse {
   return errorResponse(status, { message, type, code });
 }
+
+// ── Messages API errors (Anthropic format) ──
+
+export function anthropicError(
+  status: number,
+  message: string,
+  type: string
+): NextResponse {
+  return NextResponse.json(
+    { type: "error", error: { type, message } },
+    { status }
+  );
+}

--- a/src/lib/messages/__tests__/formatting.test.ts
+++ b/src/lib/messages/__tests__/formatting.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatResponse,
+  formatSSEStream,
+} from "@/lib/messages/formatting";
+import type { ContentBlock, OutputMessage, SSEEvent } from "@/lib/messages/types";
+
+async function readStream(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+
+  output += decoder.decode();
+  return output;
+}
+
+function parseSSE(text: string) {
+  return text
+    .trim()
+    .split("\n\n")
+    .filter(Boolean)
+    .map((chunk) => {
+      const lines = chunk.split("\n");
+      const eventLine = lines.find((line) => line.startsWith("event: "));
+      const dataLine = lines.find((line) => line.startsWith("data: "));
+
+      if (!eventLine || !dataLine) {
+        throw new Error("Invalid SSE frame");
+      }
+
+      const event = eventLine.slice("event: ".length);
+      const data = JSON.parse(dataLine.slice("data: ".length)) as SSEEvent;
+      return { event, data };
+    });
+}
+
+function outputMessage(content: ContentBlock[]): OutputMessage {
+  return { role: "assistant", content };
+}
+
+describe("formatResponse", () => {
+  it("sets stop_reason to end_turn for text-only responses", () => {
+    const response = formatResponse(
+      "model",
+      outputMessage([{ type: "text", text: "Hello" }])
+    );
+
+    expect(response.stop_reason).toBe("end_turn");
+    expect(response.content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("sets stop_reason to tool_use when tool blocks are present", () => {
+    const response = formatResponse(
+      "model",
+      outputMessage([
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "get_weather",
+          input: { city: "SF" },
+        },
+      ])
+    );
+
+    expect(response.stop_reason).toBe("tool_use");
+  });
+});
+
+describe("formatSSEStream", () => {
+  it("formats text blocks into SSE events", async () => {
+    const stream = formatSSEStream(
+      "model",
+      outputMessage([{ type: "text", text: "Hello" }])
+    );
+    const events = parseSSE(await readStream(stream));
+    const eventTypes = events.map((event) => event.event);
+
+    expect(eventTypes).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+
+    events.forEach(({ event, data }) => {
+      expect(data.type).toBe(event);
+    });
+
+    const deltaEvent = events[2].data as {
+      delta: { type: string; text: string };
+    };
+    expect(deltaEvent.delta.type).toBe("text_delta");
+    expect(deltaEvent.delta.text).toBe("Hello");
+  });
+
+  it("formats tool_use blocks into input_json_delta events", async () => {
+    const stream = formatSSEStream(
+      "model",
+      outputMessage([
+        {
+          type: "tool_use",
+          id: "toolu_2",
+          name: "lookup",
+          input: { city: "SF" },
+        },
+      ])
+    );
+
+    const events = parseSSE(await readStream(stream));
+    const deltaEvent = events[2].data as {
+      delta: { type: string; partial_json: string };
+    };
+
+    expect(deltaEvent.delta.type).toBe("input_json_delta");
+    expect(deltaEvent.delta.partial_json).toBe("{\"city\":\"SF\"}");
+  });
+});

--- a/src/lib/messages/__tests__/matching.test.ts
+++ b/src/lib/messages/__tests__/matching.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMatchError,
+  matchInput,
+  normalizeRequest,
+} from "@/lib/messages/matching";
+import type { ContentBlock, TestItemRecord } from "@/lib/messages/types";
+
+const textBlock = (text: string): ContentBlock => ({ type: "text", text });
+
+const toolUseBlock = (
+  id: string,
+  name: string,
+  input: Record<string, unknown>
+): ContentBlock => ({
+  type: "tool_use",
+  id,
+  name,
+  input,
+});
+
+const toolResultBlock = (
+  tool_use_id: string,
+  content: string | Record<string, unknown>
+): ContentBlock => ({
+  type: "tool_result",
+  tool_use_id,
+  content,
+});
+
+const systemItem = (
+  position: number,
+  content: { text: string } | { blocks: ContentBlock[] }
+): TestItemRecord => ({
+  id: `sys-${position}`,
+  position,
+  type: "anthropic_system",
+  content,
+});
+
+const messageItem = (
+  position: number,
+  role: "user" | "assistant",
+  content: string | ContentBlock[]
+): TestItemRecord => ({
+  id: `msg-${position}`,
+  position,
+  type: "anthropic_message",
+  content: { role, content },
+});
+
+describe("matchInput", () => {
+  it("matches a system + user input and returns the next assistant message", () => {
+    const sequence = [
+      systemItem(0, { text: "You are helpful." }),
+      messageItem(1, "user", "Hello"),
+      messageItem(2, "assistant", "Hi there"),
+    ];
+
+    const input = normalizeRequest("You are helpful.", [
+      { role: "user", content: "Hello" },
+    ]);
+
+    const result = matchInput(sequence, input);
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputMessage.role).toBe("assistant");
+      expect(result.outputMessage.content).toEqual([textBlock("Hi there")]);
+    }
+  });
+
+  it("matches multi-turn history with tool use", () => {
+    const sequence = [
+      systemItem(0, { text: "You are a weather assistant." }),
+      messageItem(1, "user", [textBlock("Weather in SF?")]),
+      messageItem(2, "assistant", [
+        toolUseBlock("toolu_01", "get_weather", { city: "SF" }),
+      ]),
+      messageItem(3, "user", [
+        toolResultBlock("toolu_01", "65F"),
+      ]),
+      messageItem(4, "assistant", [textBlock("It is 65F.")]),
+    ];
+
+    const firstInput = normalizeRequest("You are a weather assistant.", [
+      { role: "user", content: "Weather in SF?" },
+    ]);
+    const firstResult = matchInput(sequence, firstInput);
+    expect(isMatchError(firstResult)).toBe(false);
+    if (!isMatchError(firstResult)) {
+      expect(firstResult.outputMessage.content).toEqual([
+        toolUseBlock("toolu_01", "get_weather", { city: "SF" }),
+      ]);
+    }
+
+    const secondInput = normalizeRequest("You are a weather assistant.", [
+      { role: "user", content: "Weather in SF?" },
+      {
+        role: "assistant",
+        content: [toolUseBlock("toolu_01", "get_weather", { city: "SF" })],
+      },
+      {
+        role: "user",
+        content: [toolResultBlock("toolu_01", "65F")],
+      },
+    ]);
+    const secondResult = matchInput(sequence, secondInput);
+    expect(isMatchError(secondResult)).toBe(false);
+    if (!isMatchError(secondResult)) {
+      expect(secondResult.outputMessage.content).toEqual([
+        textBlock("It is 65F."),
+      ]);
+    }
+  });
+
+  it("matches string message content against stored blocks", () => {
+    const sequence = [
+      messageItem(0, "user", [textBlock("Hello")]),
+      messageItem(1, "assistant", [textBlock("Hi")]),
+    ];
+
+    const input = normalizeRequest(undefined, [
+      { role: "user", content: "Hello" },
+    ]);
+    const result = matchInput(sequence, input);
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputMessage.content).toEqual([textBlock("Hi")]);
+    }
+  });
+
+  it("returns sequence_exhausted when input extends beyond the sequence", () => {
+    const sequence = [
+      messageItem(0, "user", "Hello"),
+      messageItem(1, "assistant", "Hi"),
+    ];
+
+    const input = normalizeRequest(undefined, [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
+      { role: "user", content: "Extra" },
+    ]);
+
+    const result = matchInput(sequence, input);
+    expect(isMatchError(result)).toBe(true);
+    if (isMatchError(result)) {
+      expect(result.code).toBe("sequence_exhausted");
+    }
+  });
+
+  it("matches tool_use inputs using JSON deep equality", () => {
+    const sequence = [
+      messageItem(0, "user", "Call tool"),
+      messageItem(1, "assistant", [
+        toolUseBlock("toolu_99", "lookup", { city: "SF", units: "f" }),
+      ]),
+      messageItem(2, "user", [toolResultBlock("toolu_99", "ok")]),
+      messageItem(3, "assistant", [textBlock("Done")]),
+    ];
+
+    const input = normalizeRequest(undefined, [
+      { role: "user", content: "Call tool" },
+      {
+        role: "assistant",
+        content: [
+          toolUseBlock("toolu_99", "lookup", { units: "f", city: "SF" }),
+        ],
+      },
+      { role: "user", content: [toolResultBlock("toolu_99", "ok")] },
+    ]);
+
+    const result = matchInput(sequence, input);
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputMessage.content).toEqual([textBlock("Done")]);
+    }
+  });
+});

--- a/src/lib/messages/__tests__/matching.test.ts
+++ b/src/lib/messages/__tests__/matching.test.ts
@@ -175,4 +175,80 @@ describe("matchInput", () => {
       expect(result.outputMessage.content).toEqual([textBlock("Done")]);
     }
   });
+
+  it("returns input_mismatch when system prompt is missing", () => {
+    const sequence = [
+      systemItem(0, { text: "System prompt" }),
+      messageItem(1, "assistant", "Hi"),
+    ];
+
+    const input = normalizeRequest(undefined, []);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(true);
+    if (isMatchError(result)) {
+      expect(result.code).toBe("input_mismatch");
+      expect(result.message).toContain("expected system prompt");
+    }
+  });
+
+  it("returns input_mismatch when system prompt differs", () => {
+    const sequence = [
+      systemItem(0, { text: "Expected" }),
+      messageItem(1, "assistant", "Hi"),
+    ];
+
+    const input = normalizeRequest("Actual", []);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(true);
+    if (isMatchError(result)) {
+      expect(result.code).toBe("input_mismatch");
+      expect(result.message).toContain("expected system content");
+    }
+  });
+
+  it("returns input_mismatch when role mismatches", () => {
+    const sequence = [
+      messageItem(0, "user", "Hello"),
+      messageItem(1, "assistant", "Hi"),
+    ];
+
+    const input = normalizeRequest(undefined, [
+      { role: "assistant", content: "Hello" },
+    ]);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(true);
+    if (isMatchError(result)) {
+      expect(result.code).toBe("input_mismatch");
+      expect(result.message).toContain("expected role 'user'");
+    }
+  });
+
+  it("returns input_mismatch when content mismatches", () => {
+    const sequence = [
+      messageItem(0, "user", "Hello"),
+      messageItem(1, "assistant", "Hi"),
+    ];
+
+    const input = normalizeRequest(undefined, [
+      { role: "user", content: "Different" },
+    ]);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(true);
+    if (isMatchError(result)) {
+      expect(result.code).toBe("input_mismatch");
+      expect(result.message).toContain("expected content");
+    }
+  });
+
+  it("returns sequence_exhausted for an empty sequence", () => {
+    const result = matchInput([], normalizeRequest(undefined, []));
+    expect(isMatchError(result)).toBe(true);
+    if (isMatchError(result)) {
+      expect(result.code).toBe("sequence_exhausted");
+    }
+  });
 });

--- a/src/lib/messages/formatting.ts
+++ b/src/lib/messages/formatting.ts
@@ -24,8 +24,8 @@ function stopReasonFor(content: ContentBlock[]): StopReason {
     : "end_turn";
 }
 
-function normalizeBlocks(content: ContentBlock[]): ContentBlock[] {
-  return content;
+function assertNever(value: never, message: string): never {
+  throw new Error(message);
 }
 
 export function formatResponse(
@@ -33,7 +33,7 @@ export function formatResponse(
   outputMessage: OutputMessage,
   metadata: MessageMetadata = createMessageMetadata()
 ): AnthropicMessageResponse {
-  const content = normalizeBlocks(outputMessage.content);
+  const content = outputMessage.content;
 
   return {
     id: metadata.messageId,
@@ -48,41 +48,43 @@ export function formatResponse(
 }
 
 function initialContentBlock(block: ContentBlock): ContentBlock {
-  if (block.type === "text") {
-    return { type: "text", text: "" };
+  switch (block.type) {
+    case "text":
+      return { type: "text", text: "" };
+    case "tool_use":
+      return {
+        type: "tool_use",
+        id: block.id,
+        name: block.name,
+        input: {},
+      };
+    case "tool_result":
+      return assertNever(
+        block as never,
+        "Tool result blocks are not valid in assistant output"
+      );
+    default:
+      return assertNever(block as never, "Unexpected content block type");
   }
-  if (block.type === "tool_use") {
-    return {
-      type: "tool_use",
-      id: block.id,
-      name: block.name,
-      input: {},
-    };
-  }
-  return {
-    type: "tool_result",
-    tool_use_id: block.tool_use_id,
-    content: "",
-  };
 }
 
 function blockDelta(block: ContentBlock): TextDelta | InputJsonDelta {
-  if (block.type === "text") {
-    return { type: "text_delta", text: block.text };
+  switch (block.type) {
+    case "text":
+      return { type: "text_delta", text: block.text };
+    case "tool_use":
+      return {
+        type: "input_json_delta",
+        partial_json: JSON.stringify(block.input),
+      };
+    case "tool_result":
+      return assertNever(
+        block as never,
+        "Tool result blocks are not valid in assistant output"
+      );
+    default:
+      return assertNever(block as never, "Unexpected content block type");
   }
-  if (block.type === "tool_use") {
-    return {
-      type: "input_json_delta",
-      partial_json: JSON.stringify(block.input),
-    };
-  }
-  return {
-    type: "text_delta",
-    text:
-      typeof block.content === "string"
-        ? block.content
-        : JSON.stringify(block.content),
-  };
 }
 
 export function formatSSEStream(
@@ -90,7 +92,7 @@ export function formatSSEStream(
   outputMessage: OutputMessage,
   metadata: MessageMetadata = createMessageMetadata()
 ): ReadableStream<Uint8Array> {
-  const content = normalizeBlocks(outputMessage.content);
+  const content = outputMessage.content;
   const stopReason = stopReasonFor(content);
 
   const startMessage: AnthropicMessageStart = {

--- a/src/lib/messages/formatting.ts
+++ b/src/lib/messages/formatting.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "crypto";
+import type {
+  AnthropicMessageResponse,
+  AnthropicMessageStart,
+  ContentBlock,
+  InputJsonDelta,
+  OutputMessage,
+  SSEEvent,
+  StopReason,
+  TextDelta,
+} from "@/lib/messages/types";
+
+export type MessageMetadata = {
+  messageId: string;
+};
+
+export function createMessageMetadata(): MessageMetadata {
+  return { messageId: `msg_${randomUUID()}` };
+}
+
+function stopReasonFor(content: ContentBlock[]): StopReason {
+  return content.some((block) => block.type === "tool_use")
+    ? "tool_use"
+    : "end_turn";
+}
+
+function normalizeBlocks(content: ContentBlock[]): ContentBlock[] {
+  return content;
+}
+
+export function formatResponse(
+  model: string,
+  outputMessage: OutputMessage,
+  metadata: MessageMetadata = createMessageMetadata()
+): AnthropicMessageResponse {
+  const content = normalizeBlocks(outputMessage.content);
+
+  return {
+    id: metadata.messageId,
+    type: "message",
+    role: "assistant",
+    model,
+    content,
+    stop_reason: stopReasonFor(content),
+    stop_sequence: null,
+    usage: { input_tokens: 0, output_tokens: 0 },
+  };
+}
+
+function initialContentBlock(block: ContentBlock): ContentBlock {
+  if (block.type === "text") {
+    return { type: "text", text: "" };
+  }
+  if (block.type === "tool_use") {
+    return {
+      type: "tool_use",
+      id: block.id,
+      name: block.name,
+      input: {},
+    };
+  }
+  return {
+    type: "tool_result",
+    tool_use_id: block.tool_use_id,
+    content: "",
+  };
+}
+
+function blockDelta(block: ContentBlock): TextDelta | InputJsonDelta {
+  if (block.type === "text") {
+    return { type: "text_delta", text: block.text };
+  }
+  if (block.type === "tool_use") {
+    return {
+      type: "input_json_delta",
+      partial_json: JSON.stringify(block.input),
+    };
+  }
+  return {
+    type: "text_delta",
+    text:
+      typeof block.content === "string"
+        ? block.content
+        : JSON.stringify(block.content),
+  };
+}
+
+export function formatSSEStream(
+  model: string,
+  outputMessage: OutputMessage,
+  metadata: MessageMetadata = createMessageMetadata()
+): ReadableStream<Uint8Array> {
+  const content = normalizeBlocks(outputMessage.content);
+  const stopReason = stopReasonFor(content);
+
+  const startMessage: AnthropicMessageStart = {
+    id: metadata.messageId,
+    type: "message",
+    role: "assistant",
+    model,
+    content: [],
+    stop_reason: null,
+    stop_sequence: null,
+    usage: { input_tokens: 0, output_tokens: 0 },
+  };
+
+  const events: SSEEvent[] = [
+    { type: "message_start", message: startMessage },
+  ];
+
+  content.forEach((block, index) => {
+    events.push({
+      type: "content_block_start",
+      index,
+      content_block: initialContentBlock(block),
+    });
+
+    events.push({
+      type: "content_block_delta",
+      index,
+      delta: blockDelta(block),
+    });
+
+    events.push({ type: "content_block_stop", index });
+  });
+
+  events.push({
+    type: "message_delta",
+    delta: { stop_reason: stopReason, stop_sequence: null },
+    usage: { output_tokens: 0 },
+  });
+  events.push({ type: "message_stop" });
+
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        const payload =
+          `event: ${event.type}\n` +
+          `data: ${JSON.stringify(event)}\n\n`;
+        controller.enqueue(encoder.encode(payload));
+      }
+      controller.close();
+    },
+  });
+}

--- a/src/lib/messages/matching.ts
+++ b/src/lib/messages/matching.ts
@@ -1,0 +1,315 @@
+import { z } from "zod";
+import type {
+  ContentBlock,
+  MessageContent,
+  NormalizedInput,
+  NormalizedMessage,
+  OutputMessage,
+  TestItemRecord,
+} from "@/lib/messages/types";
+
+const TextBlockSchema = z
+  .object({
+    type: z.literal("text"),
+    text: z.string(),
+  })
+  .passthrough();
+
+const ToolUseBlockSchema = z
+  .object({
+    type: z.literal("tool_use"),
+    id: z.string(),
+    name: z.string(),
+    input: z.unknown(),
+  })
+  .passthrough();
+
+const ToolResultBlockSchema = z
+  .object({
+    type: z.literal("tool_result"),
+    tool_use_id: z.string(),
+    content: z.unknown(),
+  })
+  .passthrough();
+
+export const ContentBlockSchema = z.discriminatedUnion("type", [
+  TextBlockSchema,
+  ToolUseBlockSchema,
+  ToolResultBlockSchema,
+]);
+
+const MessageContentSchema = z.union([
+  z.string(),
+  z.array(ContentBlockSchema),
+]);
+
+export const MessageSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: MessageContentSchema,
+});
+
+export const MessagesSchema = z.array(MessageSchema);
+
+export const SystemSchema = z.union([
+  z.string(),
+  z.array(ContentBlockSchema),
+]);
+
+const StoredSystemContentSchema = z.union([
+  z.object({ text: z.string() }).passthrough(),
+  z.object({ blocks: z.array(ContentBlockSchema) }).passthrough(),
+]);
+
+const StoredMessageContentSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: MessageContentSchema,
+});
+
+const TestItemRecordSchema = z.discriminatedUnion("type", [
+  z.object({
+    id: z.string(),
+    position: z.number().int(),
+    type: z.literal("anthropic_system"),
+    content: StoredSystemContentSchema,
+  }),
+  z.object({
+    id: z.string(),
+    position: z.number().int(),
+    type: z.literal("anthropic_message"),
+    content: StoredMessageContentSchema,
+  }),
+]);
+
+const TestItemSequenceSchema = z.array(TestItemRecordSchema);
+
+interface MatchSuccess {
+  outputMessage: OutputMessage;
+}
+
+interface MatchError {
+  status: number;
+  message: string;
+  type: string;
+  code: string;
+}
+
+type MatchResult = MatchSuccess | MatchError;
+
+export function isMatchError(result: MatchResult): result is MatchError {
+  return "status" in result;
+}
+
+// Boundary helpers: normalize/validate external inputs.
+export function parseTestSequence(sequence: unknown): TestItemRecord[] {
+  const parsed = TestItemSequenceSchema.safeParse(sequence);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = issue.path.length > 0 ? issue.path.join(".") : "sequence";
+    throw new Error(`Invalid test item sequence: ${path}: ${issue.message}`);
+  }
+  return parsed.data as TestItemRecord[];
+}
+
+export function normalizeRequest(
+  system: z.infer<typeof SystemSchema> | undefined,
+  messages: z.infer<typeof MessagesSchema>
+): NormalizedInput {
+  return {
+    system: system
+      ? { blocks: normalizeBlocks(system as string | ContentBlock[]) }
+      : null,
+    messages: messages.map((message) => ({
+      role: message.role,
+      content: normalizeBlocks(message.content as string | ContentBlock[]),
+    })),
+  };
+}
+
+function normalizeBlocks(content: string | ContentBlock[]): ContentBlock[] {
+  if (typeof content === "string") {
+    return [{ type: "text", text: content }];
+  }
+  return content;
+}
+
+function normalizeStoredMessage(content: MessageContent): NormalizedMessage {
+  return {
+    role: content.role,
+    content: normalizeBlocks(content.content),
+  };
+}
+
+function normalizeStoredSystem(
+  content: TestItemRecord & { type: "anthropic_system" }
+): ContentBlock[] {
+  if ("text" in content.content) {
+    return [{ type: "text", text: content.content.text }];
+  }
+  return content.content.blocks;
+}
+
+function mismatch(position: number, message: string): MatchError {
+  return {
+    status: 400,
+    message: `Input mismatch at position ${position}: ${message}`,
+    type: "invalid_request_error",
+    code: "input_mismatch",
+  };
+}
+
+function sequenceExhausted(): MatchError {
+  return {
+    status: 400,
+    message: "Input extends beyond the defined test sequence",
+    type: "invalid_request_error",
+    code: "sequence_exhausted",
+  };
+}
+
+function formatBlocks(blocks: ContentBlock[]): string {
+  return JSON.stringify(blocks);
+}
+
+function blocksEqual(expected: ContentBlock[], actual: ContentBlock[]): boolean {
+  if (expected.length !== actual.length) return false;
+  return expected.every((block, index) => compareBlock(block, actual[index]));
+}
+
+function compareBlock(expected: ContentBlock, actual: ContentBlock): boolean {
+  if (expected.type !== actual.type) return false;
+
+  if (expected.type === "text" && actual.type === "text") {
+    return expected.text === actual.text;
+  }
+
+  if (expected.type === "tool_use" && actual.type === "tool_use") {
+    return (
+      expected.id === actual.id &&
+      expected.name === actual.name &&
+      jsonDeepEqual(expected.input, actual.input)
+    );
+  }
+
+  if (expected.type === "tool_result" && actual.type === "tool_result") {
+    return (
+      expected.tool_use_id === actual.tool_use_id &&
+      jsonDeepEqual(expected.content, actual.content)
+    );
+  }
+
+  return false;
+}
+
+function jsonDeepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== typeof b) return false;
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((val, i) => jsonDeepEqual(val, b[i]));
+  }
+
+  if (typeof a === "object" && typeof b === "object") {
+    const aObj = a as Record<string, unknown>;
+    const bObj = b as Record<string, unknown>;
+    const aKeys = Object.keys(aObj);
+    const bKeys = Object.keys(bObj);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(
+      (key) => key in bObj && jsonDeepEqual(aObj[key], bObj[key])
+    );
+  }
+
+  return false;
+}
+
+// Internal matching logic (assumes validated inputs).
+export function matchInput(
+  sequence: TestItemRecord[],
+  input: NormalizedInput
+): MatchResult {
+  let messageIndex = 0;
+  let systemMatched = false;
+
+  for (const item of sequence) {
+    if (item.type === "anthropic_system") {
+      if (systemMatched) {
+        return mismatch(item.position, "unexpected extra system prompt");
+      }
+      if (!input.system) {
+        return mismatch(item.position, "expected system prompt, got none");
+      }
+      const expectedBlocks = normalizeStoredSystem(item);
+      const actualBlocks = input.system.blocks;
+      if (!blocksEqual(expectedBlocks, actualBlocks)) {
+        return mismatch(
+          item.position,
+          `expected system content ${formatBlocks(expectedBlocks)}, ` +
+            `got ${formatBlocks(actualBlocks)}`
+        );
+      }
+      systemMatched = true;
+      continue;
+    }
+
+    const expectedMessage = normalizeStoredMessage(item.content);
+
+    if (expectedMessage.role === "user") {
+      if (messageIndex >= input.messages.length) {
+        return mismatch(item.position, "expected user message, got none");
+      }
+
+      const actual = input.messages[messageIndex];
+      if (actual.role !== "user") {
+        return mismatch(
+          item.position,
+          `expected role 'user', got '${actual.role}'`
+        );
+      }
+
+      if (!blocksEqual(expectedMessage.content, actual.content)) {
+        return mismatch(
+          item.position,
+          `expected content ${formatBlocks(expectedMessage.content)}, ` +
+            `got ${formatBlocks(actual.content)}`
+        );
+      }
+
+      messageIndex += 1;
+      continue;
+    }
+
+    if (messageIndex >= input.messages.length) {
+      return { outputMessage: expectedMessage as OutputMessage };
+    }
+
+    const actual = input.messages[messageIndex];
+    if (actual.role !== "assistant") {
+      return mismatch(
+        item.position,
+        `expected role 'assistant', got '${actual.role}'`
+      );
+    }
+
+    if (!blocksEqual(expectedMessage.content, actual.content)) {
+      return mismatch(
+        item.position,
+        `expected content ${formatBlocks(expectedMessage.content)}, ` +
+          `got ${formatBlocks(actual.content)}`
+      );
+    }
+
+    messageIndex += 1;
+  }
+
+  if (messageIndex < input.messages.length) {
+    return sequenceExhausted();
+  }
+
+  if (input.system && !systemMatched) {
+    return mismatch(0, "unexpected system prompt");
+  }
+
+  return sequenceExhausted();
+}

--- a/src/lib/messages/matching.ts
+++ b/src/lib/messages/matching.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ContentBlockSchema } from "@/lib/messages/schemas";
 import type {
   ContentBlock,
   MessageContent,
@@ -7,36 +8,6 @@ import type {
   OutputMessage,
   TestItemRecord,
 } from "@/lib/messages/types";
-
-const TextBlockSchema = z
-  .object({
-    type: z.literal("text"),
-    text: z.string(),
-  })
-  .passthrough();
-
-const ToolUseBlockSchema = z
-  .object({
-    type: z.literal("tool_use"),
-    id: z.string(),
-    name: z.string(),
-    input: z.unknown(),
-  })
-  .passthrough();
-
-const ToolResultBlockSchema = z
-  .object({
-    type: z.literal("tool_result"),
-    tool_use_id: z.string(),
-    content: z.unknown(),
-  })
-  .passthrough();
-
-export const ContentBlockSchema = z.discriminatedUnion("type", [
-  TextBlockSchema,
-  ToolUseBlockSchema,
-  ToolResultBlockSchema,
-]);
 
 const MessageContentSchema = z.union([
   z.string(),
@@ -142,6 +113,7 @@ function normalizeStoredMessage(content: MessageContent): NormalizedMessage {
 function normalizeStoredSystem(
   content: TestItemRecord & { type: "anthropic_system" }
 ): ContentBlock[] {
+  // Stored system content is a union without a discriminant, so probe by key.
   if ("text" in content.content) {
     return [{ type: "text", text: content.content.text }];
   }
@@ -170,6 +142,10 @@ function formatBlocks(blocks: ContentBlock[]): string {
   return JSON.stringify(blocks);
 }
 
+function assertNever(value: never, message: string): never {
+  throw new Error(message);
+}
+
 function blocksEqual(expected: ContentBlock[], actual: ContentBlock[]): boolean {
   if (expected.length !== actual.length) return false;
   return expected.every((block, index) => compareBlock(block, actual[index]));
@@ -178,26 +154,29 @@ function blocksEqual(expected: ContentBlock[], actual: ContentBlock[]): boolean 
 function compareBlock(expected: ContentBlock, actual: ContentBlock): boolean {
   if (expected.type !== actual.type) return false;
 
-  if (expected.type === "text" && actual.type === "text") {
-    return expected.text === actual.text;
+  switch (expected.type) {
+    case "text":
+      return expected.text === (actual as typeof expected).text;
+    case "tool_use":
+      {
+        const actualToolUse = actual as typeof expected;
+        return (
+          expected.id === actualToolUse.id &&
+          expected.name === actualToolUse.name &&
+          jsonDeepEqual(expected.input, actualToolUse.input)
+        );
+      }
+    case "tool_result":
+      {
+        const actualToolResult = actual as typeof expected;
+        return (
+          expected.tool_use_id === actualToolResult.tool_use_id &&
+          jsonDeepEqual(expected.content, actualToolResult.content)
+        );
+      }
+    default:
+      return assertNever(expected, "Unexpected content block type");
   }
-
-  if (expected.type === "tool_use" && actual.type === "tool_use") {
-    return (
-      expected.id === actual.id &&
-      expected.name === actual.name &&
-      jsonDeepEqual(expected.input, actual.input)
-    );
-  }
-
-  if (expected.type === "tool_result" && actual.type === "tool_result") {
-    return (
-      expected.tool_use_id === actual.tool_use_id &&
-      jsonDeepEqual(expected.content, actual.content)
-    );
-  }
-
-  return false;
 }
 
 function jsonDeepEqual(a: unknown, b: unknown): boolean {

--- a/src/lib/messages/request.ts
+++ b/src/lib/messages/request.ts
@@ -40,14 +40,20 @@ export async function parseMessagesRequestBody(
     const issue = parsed.error.issues[0];
     const path = issue.path.join(".");
 
-    const isMissing = (field: string) =>
+    const isMissingModel =
       issue.code === "invalid_type" &&
-      path === field &&
-      (("received" in issue && issue.received === "undefined") ||
-        issue.message.toLowerCase().includes("required") ||
-        issue.message.includes("received undefined"));
+      path === "model" &&
+      issue.message.includes("received undefined");
+    const isMissingMaxTokens =
+      issue.code === "invalid_type" &&
+      path === "max_tokens" &&
+      issue.message.includes("received undefined");
+    const isMissingMessages =
+      issue.code === "invalid_type" &&
+      path === "messages" &&
+      issue.message.includes("received undefined");
 
-    if (isMissing("model")) {
+    if (isMissingModel) {
       return {
         ok: false,
         error: anthropicError(
@@ -58,7 +64,7 @@ export async function parseMessagesRequestBody(
       };
     }
 
-    if (isMissing("max_tokens")) {
+    if (isMissingMaxTokens) {
       return {
         ok: false,
         error: anthropicError(
@@ -69,7 +75,7 @@ export async function parseMessagesRequestBody(
       };
     }
 
-    if (isMissing("messages")) {
+    if (isMissingMessages) {
       return {
         ok: false,
         error: anthropicError(

--- a/src/lib/messages/request.ts
+++ b/src/lib/messages/request.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { anthropicError } from "@/lib/errors";
+import {
+  MessagesSchema,
+  SystemSchema,
+} from "@/lib/messages/matching";
+
+const RequestSchema = z
+  .object({
+    model: z.string().min(1, { message: "model is required" }),
+    max_tokens: z.number().int().positive({ message: "max_tokens is required" }),
+    system: SystemSchema.optional(),
+    messages: MessagesSchema,
+    stream: z.boolean().optional(),
+  })
+  .passthrough();
+
+export type MessagesRequestBody = z.infer<typeof RequestSchema>;
+
+type RequestParseResult =
+  | { ok: true; data: MessagesRequestBody }
+  | { ok: false; error: NextResponse };
+
+export async function parseMessagesRequestBody(
+  request: NextRequest
+): Promise<RequestParseResult> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      ok: false,
+      error: anthropicError(400, "Invalid JSON body", "invalid_request_error"),
+    };
+  }
+
+  const parsed = RequestSchema.safeParse(body);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = issue.path.join(".");
+
+    const isMissing = (field: string) =>
+      issue.code === "invalid_type" &&
+      path === field &&
+      (("received" in issue && issue.received === "undefined") ||
+        issue.message.toLowerCase().includes("required") ||
+        issue.message.includes("received undefined"));
+
+    if (isMissing("model")) {
+      return {
+        ok: false,
+        error: anthropicError(
+          400,
+          "Missing required field: model",
+          "invalid_request_error"
+        ),
+      };
+    }
+
+    if (isMissing("max_tokens")) {
+      return {
+        ok: false,
+        error: anthropicError(
+          400,
+          "Missing required field: max_tokens",
+          "invalid_request_error"
+        ),
+      };
+    }
+
+    if (isMissing("messages")) {
+      return {
+        ok: false,
+        error: anthropicError(
+          400,
+          "Missing required field: messages",
+          "invalid_request_error"
+        ),
+      };
+    }
+
+    const prefix = issue.path.length > 0 ? `${path}: ` : "";
+    return {
+      ok: false,
+      error: anthropicError(
+        400,
+        `${prefix}${issue.message}`,
+        "invalid_request_error"
+      ),
+    };
+  }
+
+  return { ok: true, data: parsed.data };
+}

--- a/src/lib/messages/resolve.ts
+++ b/src/lib/messages/resolve.ts
@@ -1,0 +1,180 @@
+import type { Organization, Test, TestSuite } from "@prisma/client";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { anthropicError } from "@/lib/errors";
+import {
+  isMatchError,
+  matchInput,
+  normalizeRequest,
+  parseTestSequence,
+} from "@/lib/messages/matching";
+import type {
+  NormalizedInput,
+  OutputMessage,
+} from "@/lib/messages/types";
+import type { MessagesRequestBody } from "@/lib/messages/request";
+
+type MatchErrorDetail = {
+  status: number;
+  message: string;
+  type: string;
+  code: string;
+};
+
+export type MessageMatchSuccess = {
+  ok: true;
+  org: Organization;
+  suite: TestSuite;
+  test: Test;
+  normalizedInput: NormalizedInput;
+  outputMessage: OutputMessage;
+};
+
+export type MessageMatchError = {
+  ok: false;
+  response: NextResponse;
+  error: MatchErrorDetail;
+  org: Organization | null;
+  suite: TestSuite | null;
+  test: Test | null;
+};
+
+export type MessageMatchResult = MessageMatchSuccess | MessageMatchError;
+
+type ResolveMatchInput = {
+  orgSlug: string;
+  suiteName: string;
+  model: string;
+  system: MessagesRequestBody["system"];
+  messages: MessagesRequestBody["messages"];
+  org?: Organization | null;
+};
+
+function buildError(
+  status: number,
+  message: string,
+  type: string,
+  code: string
+): MatchErrorDetail {
+  return { status, message, type, code };
+}
+
+export async function resolveMessageMatch({
+  orgSlug,
+  suiteName,
+  model,
+  system,
+  messages,
+  org: orgOverride,
+}: ResolveMatchInput): Promise<MessageMatchResult> {
+  const org =
+    orgOverride ??
+    (await prisma.organization.findUnique({
+      where: { slug: orgSlug },
+    }));
+  if (!org) {
+    const error = buildError(
+      404,
+      `Organization '${orgSlug}' not found`,
+      "not_found_error",
+      "org_not_found"
+    );
+    return {
+      ok: false,
+      response: anthropicError(error.status, error.message, error.type),
+      error,
+      org: null,
+      suite: null,
+      test: null,
+    };
+  }
+
+  const suite = await prisma.testSuite.findUnique({
+    where: { orgId_name: { orgId: org.id, name: suiteName } },
+  });
+  if (!suite) {
+    const error = buildError(
+      404,
+      `Test suite '${suiteName}' not found in organization '${orgSlug}'`,
+      "not_found_error",
+      "suite_not_found"
+    );
+    return {
+      ok: false,
+      response: anthropicError(error.status, error.message, error.type),
+      error,
+      org,
+      suite: null,
+      test: null,
+    };
+  }
+
+  if (suite.protocol !== "anthropic") {
+    const error = buildError(
+      400,
+      `Test suite '${suiteName}' does not support the Anthropic protocol`,
+      "invalid_request_error",
+      "suite_protocol_mismatch"
+    );
+    return {
+      ok: false,
+      response: anthropicError(error.status, error.message, error.type),
+      error,
+      org,
+      suite,
+      test: null,
+    };
+  }
+
+  const test = await prisma.test.findUnique({
+    where: { testSuiteId_name: { testSuiteId: suite.id, name: model } },
+  });
+  if (!test) {
+    const error = buildError(
+      404,
+      `Model '${model}' not found in suite '${suiteName}'`,
+      "not_found_error",
+      "model_not_found"
+    );
+    return {
+      ok: false,
+      response: anthropicError(error.status, error.message, error.type),
+      error,
+      org,
+      suite,
+      test: null,
+    };
+  }
+
+  const rawSequence = await prisma.testItem.findMany({
+    where: { testId: test.id },
+    orderBy: { position: "asc" },
+  });
+  const sequence = parseTestSequence(rawSequence);
+
+  const normalizedInput = normalizeRequest(system, messages);
+  const result = matchInput(sequence, normalizedInput);
+  if (isMatchError(result)) {
+    return {
+      ok: false,
+      response: anthropicError(
+        result.status,
+        result.message,
+        result.type
+      ),
+      error: result,
+      org,
+      suite,
+      test,
+    };
+  }
+
+  return {
+    ok: true,
+    org,
+    suite,
+    test,
+    normalizedInput,
+    outputMessage: result.outputMessage,
+  };
+}

--- a/src/lib/messages/schemas.ts
+++ b/src/lib/messages/schemas.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const TextBlockSchema = z
+  .object({
+    type: z.literal("text"),
+    text: z.string(),
+  })
+  .passthrough();
+
+export const ToolUseBlockSchema = z
+  .object({
+    type: z.literal("tool_use"),
+    id: z.string(),
+    name: z.string(),
+    input: z.unknown(),
+  })
+  .passthrough();
+
+export const ToolResultBlockSchema = z
+  .object({
+    type: z.literal("tool_result"),
+    tool_use_id: z.string(),
+    content: z.unknown(),
+  })
+  .passthrough();
+
+export const ContentBlockSchema = z.discriminatedUnion("type", [
+  TextBlockSchema,
+  ToolUseBlockSchema,
+  ToolResultBlockSchema,
+]);

--- a/src/lib/messages/types.ts
+++ b/src/lib/messages/types.ts
@@ -1,0 +1,150 @@
+import type { Prisma } from "@prisma/client";
+
+export type MessageRole = "user" | "assistant";
+
+export interface TextBlock extends Prisma.InputJsonObject {
+  type: "text";
+  text: string;
+}
+
+export interface ToolUseBlock extends Prisma.InputJsonObject {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Prisma.InputJsonValue;
+}
+
+export interface ToolResultBlock extends Prisma.InputJsonObject {
+  type: "tool_result";
+  tool_use_id: string;
+  content: Prisma.InputJsonValue;
+}
+
+export type ContentBlock = TextBlock | ToolUseBlock | ToolResultBlock;
+
+export type SystemContent =
+  | { text: string }
+  | { blocks: ContentBlock[] };
+
+export interface MessageContent {
+  role: MessageRole;
+  content: string | ContentBlock[];
+}
+
+export interface BaseTestItemRecord {
+  id: string;
+  position: number;
+}
+
+export interface SystemItemRecord extends BaseTestItemRecord {
+  type: "anthropic_system";
+  content: SystemContent;
+}
+
+export interface MessageItemRecord extends BaseTestItemRecord {
+  type: "anthropic_message";
+  content: MessageContent;
+}
+
+export type TestItemRecord = SystemItemRecord | MessageItemRecord;
+
+export interface NormalizedSystem {
+  blocks: ContentBlock[];
+}
+
+export interface NormalizedMessage {
+  role: MessageRole;
+  content: ContentBlock[];
+}
+
+export interface NormalizedInput {
+  system: NormalizedSystem | null;
+  messages: NormalizedMessage[];
+}
+
+export type OutputMessage = NormalizedMessage & { role: "assistant" };
+
+export type StopReason = "end_turn" | "tool_use";
+
+export interface AnthropicMessageResponse extends Prisma.InputJsonObject {
+  id: string;
+  type: "message";
+  role: "assistant";
+  model: string;
+  content: ContentBlock[];
+  stop_reason: StopReason;
+  stop_sequence: null;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+export interface AnthropicMessageStart extends Prisma.InputJsonObject {
+  id: string;
+  type: "message";
+  role: "assistant";
+  model: string;
+  content: [];
+  stop_reason: null;
+  stop_sequence: null;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+export interface TextDelta extends Prisma.InputJsonObject {
+  type: "text_delta";
+  text: string;
+}
+
+export interface InputJsonDelta extends Prisma.InputJsonObject {
+  type: "input_json_delta";
+  partial_json: string;
+}
+
+export interface MessageStartEvent {
+  type: "message_start";
+  message: AnthropicMessageStart;
+}
+
+export interface ContentBlockStartEvent {
+  type: "content_block_start";
+  index: number;
+  content_block: ContentBlock;
+}
+
+export interface ContentBlockDeltaEvent {
+  type: "content_block_delta";
+  index: number;
+  delta: TextDelta | InputJsonDelta;
+}
+
+export interface ContentBlockStopEvent {
+  type: "content_block_stop";
+  index: number;
+}
+
+export interface MessageDeltaEvent {
+  type: "message_delta";
+  delta: {
+    stop_reason: StopReason;
+    stop_sequence: null;
+  };
+  usage: {
+    output_tokens: number;
+  };
+}
+
+export interface MessageStopEvent {
+  type: "message_stop";
+}
+
+export type SSEEvent =
+  | MessageStartEvent
+  | ContentBlockStartEvent
+  | ContentBlockDeltaEvent
+  | ContentBlockStopEvent
+  | MessageDeltaEvent
+  | MessageStopEvent;

--- a/src/lib/run-tracking.ts
+++ b/src/lib/run-tracking.ts
@@ -1,0 +1,125 @@
+import type { Prisma, TestRun } from "@prisma/client";
+import { Prisma as PrismaErrors } from "@prisma/client";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+
+const RunIdSchema = z.string().uuid();
+const ClientTestNameSchema = z.string().min(1);
+
+export type RunParams = {
+  runId: string;
+  clientTestName: string;
+};
+
+export type RunParamParseResult =
+  | { ok: true; data: RunParams }
+  | { ok: false; error: Response };
+
+export type RunErrorCodes = {
+  invalidRunId: string;
+  invalidClientTestName: string;
+  runNotFound: string;
+};
+
+export type RunErrorFormatter = (
+  status: number,
+  message: string,
+  type: string,
+  code: string
+) => Response;
+
+export function parseRunParams(
+  runId: string,
+  clientTestName: string,
+  formatError: RunErrorFormatter,
+  codes: RunErrorCodes
+): RunParamParseResult {
+  const runIdResult = RunIdSchema.safeParse(runId);
+  if (!runIdResult.success) {
+    return {
+      ok: false,
+      error: formatError(
+        400,
+        "runId must be a valid UUID",
+        "invalid_request_error",
+        codes.invalidRunId
+      ),
+    };
+  }
+
+  let decodedName: string;
+  try {
+    decodedName = decodeURIComponent(clientTestName);
+  } catch {
+    return {
+      ok: false,
+      error: formatError(
+        400,
+        "clientTestName must be URL encoded",
+        "invalid_request_error",
+        codes.invalidClientTestName
+      ),
+    };
+  }
+
+  const trimmedName = decodedName.trim();
+  const nameResult = ClientTestNameSchema.safeParse(trimmedName);
+  if (!nameResult.success) {
+    return {
+      ok: false,
+      error: formatError(
+        400,
+        "clientTestName must be provided",
+        "invalid_request_error",
+        codes.invalidClientTestName
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    data: { runId: runIdResult.data, clientTestName: trimmedName },
+  };
+}
+
+export async function ensureTestRun(
+  runId: string,
+  orgId: string,
+  formatError: RunErrorFormatter,
+  codes: RunErrorCodes
+): Promise<{ ok: true; run: TestRun } | { ok: false; error: Response }> {
+  try {
+    const run = await prisma.testRun.create({
+      data: { id: runId, orgId },
+    });
+    return { ok: true as const, run };
+  } catch (error) {
+    if (
+      error instanceof PrismaErrors.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      const run = await prisma.testRun.findUnique({ where: { id: runId } });
+      if (run && run.orgId === orgId) {
+        return { ok: true as const, run };
+      }
+      return {
+        ok: false as const,
+        error: formatError(
+          404,
+          `Test run '${runId}' not found`,
+          "not_found_error",
+          codes.runNotFound
+        ),
+      };
+    }
+    throw error;
+  }
+}
+
+export function recordResponseLog(
+  data: Prisma.ResponseLogCreateInput | Prisma.ResponseLogUncheckedCreateInput
+) {
+  void prisma.responseLog
+    .create({ data })
+    .catch((error) => console.error("Failed to record response log", error));
+}

--- a/src/lib/schemas/suites.ts
+++ b/src/lib/schemas/suites.ts
@@ -3,9 +3,11 @@ import { z } from "zod";
 export const CreateSuiteSchema = z.object({
   name: z.string().min(1, { error: "name is required" }),
   description: z.string().optional(),
+  protocol: z.enum(["openai", "anthropic"]).optional(),
 });
 
 export const UpdateSuiteSchema = z.object({
   name: z.string().min(1).optional(),
   description: z.string().optional(),
+  protocol: z.enum(["openai", "anthropic"]).optional(),
 });

--- a/src/lib/schemas/suites.ts
+++ b/src/lib/schemas/suites.ts
@@ -9,5 +9,4 @@ export const CreateSuiteSchema = z.object({
 export const UpdateSuiteSchema = z.object({
   name: z.string().min(1).optional(),
   description: z.string().optional(),
-  protocol: z.enum(["openai", "anthropic"]).optional(),
 });

--- a/src/lib/schemas/test-items.ts
+++ b/src/lib/schemas/test-items.ts
@@ -45,6 +45,61 @@ const TestItemSchema = z.union([
   FunctionCallOutputItemSchema,
 ]);
 
+const AnthropicTextBlockSchema = z
+  .object({
+    type: z.literal("text"),
+    text: z.string(),
+  })
+  .passthrough();
+
+const AnthropicToolUseBlockSchema = z
+  .object({
+    type: z.literal("tool_use"),
+    id: z.string(),
+    name: z.string(),
+    input: z.unknown(),
+  })
+  .passthrough();
+
+const AnthropicToolResultBlockSchema = z
+  .object({
+    type: z.literal("tool_result"),
+    tool_use_id: z.string(),
+    content: z.unknown(),
+  })
+  .passthrough();
+
+const AnthropicContentBlockSchema = z.discriminatedUnion("type", [
+  AnthropicTextBlockSchema,
+  AnthropicToolUseBlockSchema,
+  AnthropicToolResultBlockSchema,
+]);
+
+const AnthropicSystemContentSchema = z.union([
+  z.object({ text: z.string() }).passthrough(),
+  z.object({ blocks: z.array(AnthropicContentBlockSchema) }).passthrough(),
+]);
+
+const AnthropicMessageContentSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.union([z.string(), z.array(AnthropicContentBlockSchema)]),
+});
+
+const AnthropicSystemItemSchema = z.object({
+  type: z.literal("anthropic_system"),
+  content: AnthropicSystemContentSchema,
+});
+
+const AnthropicMessageItemSchema = z.object({
+  type: z.literal("anthropic_message"),
+  content: AnthropicMessageContentSchema,
+});
+
+const AnthropicTestItemSchema = z.union([
+  AnthropicSystemItemSchema,
+  AnthropicMessageItemSchema,
+]);
+
 export const CreateTestSchema = z.object({
   name: z.string().min(1, { error: "name is required" }),
   description: z.string().optional(),
@@ -55,4 +110,18 @@ export const UpdateTestSchema = z.object({
   name: z.string().min(1).optional(),
   description: z.string().optional(),
   items: z.array(TestItemSchema).min(1).optional(),
+});
+
+export const CreateAnthropicTestSchema = z.object({
+  name: z.string().min(1, { error: "name is required" }),
+  description: z.string().optional(),
+  items: z
+    .array(AnthropicTestItemSchema)
+    .min(1, { error: "items must not be empty" }),
+});
+
+export const UpdateAnthropicTestSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  items: z.array(AnthropicTestItemSchema).min(1).optional(),
 });

--- a/src/lib/schemas/test-items.ts
+++ b/src/lib/schemas/test-items.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ContentBlockSchema } from "@/lib/messages/schemas";
 
 const InputMessageContentSchema = z.object({
   role: z.enum(["user", "system", "developer"]),
@@ -45,44 +46,14 @@ const TestItemSchema = z.union([
   FunctionCallOutputItemSchema,
 ]);
 
-const AnthropicTextBlockSchema = z
-  .object({
-    type: z.literal("text"),
-    text: z.string(),
-  })
-  .passthrough();
-
-const AnthropicToolUseBlockSchema = z
-  .object({
-    type: z.literal("tool_use"),
-    id: z.string(),
-    name: z.string(),
-    input: z.unknown(),
-  })
-  .passthrough();
-
-const AnthropicToolResultBlockSchema = z
-  .object({
-    type: z.literal("tool_result"),
-    tool_use_id: z.string(),
-    content: z.unknown(),
-  })
-  .passthrough();
-
-const AnthropicContentBlockSchema = z.discriminatedUnion("type", [
-  AnthropicTextBlockSchema,
-  AnthropicToolUseBlockSchema,
-  AnthropicToolResultBlockSchema,
-]);
-
 const AnthropicSystemContentSchema = z.union([
   z.object({ text: z.string() }).passthrough(),
-  z.object({ blocks: z.array(AnthropicContentBlockSchema) }).passthrough(),
+  z.object({ blocks: z.array(ContentBlockSchema) }).passthrough(),
 ]);
 
 const AnthropicMessageContentSchema = z.object({
   role: z.enum(["user", "assistant"]),
-  content: z.union([z.string(), z.array(AnthropicContentBlockSchema)]),
+  content: z.union([z.string(), z.array(ContentBlockSchema)]),
 });
 
 const AnthropicSystemItemSchema = z.object({


### PR DESCRIPTION
## Summary
- add suite protocol support and anthropic item validation in management APIs
- implement Anthropic Messages matching/formatting with new endpoints
- add tests and documentation for messages API

## Testing
- npm run lint
- env $(cat .env.test | xargs) npm run test
- env $(cat .env.test | xargs) npm run test:e2e

Fixes #49