### PR TITLE
feat(protocol): add anthropic support

### DIFF
--- a/e2e/helpers/management.ts
+++ b/e2e/helpers/management.ts
@@ -30,7 +30,11 @@ export async function createOrg(user: User, options: CreateOrgOptions = {}) {
   return { response, body };
 }
 
-type SuitePayload = { name: string; description?: string };
+type SuitePayload = {
+  name: string;
+  description?: string;
+  protocol?: "openai" | "anthropic";
+};
 
 export async function createSuite(
   user: User,

--- a/e2e/management/suites.test.ts
+++ b/e2e/management/suites.test.ts
@@ -19,7 +19,21 @@ describe("management api test suites", () => {
       org_id: org.id,
       name: defaultSuitePayload.name,
       description: defaultSuitePayload.description,
+      protocol: "openai",
     });
+  });
+
+  it("creates a suite with the anthropic protocol", async () => {
+    const admin = await createTestUser();
+    const { body: org } = await createOrg(admin);
+
+    const { response, body } = await createSuite(admin, org.id, {
+      name: "suite-anthropic",
+      protocol: "anthropic",
+    });
+
+    expect(response.status).toBe(201);
+    expect(body.protocol).toBe("anthropic");
   });
 
   it("allows members to create test suites", async () => {
@@ -82,7 +96,10 @@ describe("management api test suites", () => {
     const admin = await createTestUser();
     const { body: org } = await createOrg(admin);
     await createSuite(admin, org.id, { name: "suite-one" });
-    await createSuite(admin, org.id, { name: "suite-two" });
+    await createSuite(admin, org.id, {
+      name: "suite-two",
+      protocol: "anthropic",
+    });
 
     const response = await authenticatedFetch(
       managementUrl(`/orgs/${org.id}/suites`),
@@ -97,6 +114,16 @@ describe("management api test suites", () => {
       "suite-one",
       "suite-two",
     ]);
+    const protocols = Object.fromEntries(
+      body.map((item: { name: string; protocol: string }) => [
+        item.name,
+        item.protocol,
+      ])
+    );
+    expect(protocols).toEqual({
+      "suite-one": "openai",
+      "suite-two": "anthropic",
+    });
   });
 
   it("allows members to list suites", async () => {
@@ -133,7 +160,35 @@ describe("management api test suites", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body).toMatchObject({ id: suite.id, org_id: org.id });
+    expect(body).toMatchObject({
+      id: suite.id,
+      org_id: org.id,
+      protocol: "openai",
+    });
+  });
+
+  it("does not allow protocol changes via patch", async () => {
+    const admin = await createTestUser();
+    const { body: org } = await createOrg(admin);
+    const { body: suite } = await createSuite(admin, org.id);
+
+    const response = await authenticatedFetch(
+      managementUrl(`/orgs/${org.id}/suites/${suite.id}`),
+      {
+        method: "PATCH",
+        ...jsonRequest({ protocol: "anthropic" }),
+      },
+      admin
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.protocol).toBe("openai");
+
+    const persisted = await prisma.testSuite.findUnique({
+      where: { id: suite.id },
+    });
+    expect(persisted?.protocol).toBe("openai");
   });
 
   it("returns 404 when suite does not belong to org", async () => {

--- a/e2e/management/tests.test.ts
+++ b/e2e/management/tests.test.ts
@@ -4,6 +4,8 @@ import { authenticatedFetch, createTestUser } from "../helpers/auth";
 import { jsonRequest, managementUrl } from "../helpers/api";
 import { prisma } from "../helpers/prisma";
 import {
+  anthropicSimpleSequence,
+  anthropicToolSequence,
   simpleMessageSequence,
   weatherSequence,
 } from "../helpers/fixtures";
@@ -44,6 +46,24 @@ describe("management api tests", () => {
     expect(body.items.map((item: { position: number }) => item.position)).toEqual(
       weatherSequence.map((_, index) => index)
     );
+  });
+
+  it("creates anthropic tests with system and messages", async () => {
+    const admin = await createTestUser();
+    const { body: org } = await createOrg(admin);
+    const { body: suite } = await createSuite(admin, org.id, {
+      name: "anthropic-suite",
+      protocol: "anthropic",
+    });
+
+    const { response, body } = await createTest(admin, org.id, suite.id, {
+      name: "anthropic-test",
+      items: anthropicSimpleSequence,
+    });
+
+    expect(response.status).toBe(201);
+    expect(body.items).toHaveLength(anthropicSimpleSequence.length);
+    expect(body.items[0].type).toBe("anthropic_system");
   });
 
   it("rejects duplicate test names", async () => {
@@ -194,6 +214,66 @@ describe("management api tests", () => {
     const body = await response.json();
     expect(body.items).toHaveLength(weatherSequence.length);
     expect(body.items[0].content.role).toBe("system");
+  });
+
+  it("updates anthropic tests with new items", async () => {
+    const admin = await createTestUser();
+    const { body: org } = await createOrg(admin);
+    const { body: suite } = await createSuite(admin, org.id, {
+      name: "anthropic-update",
+      protocol: "anthropic",
+    });
+    const { body: test } = await createTest(admin, org.id, suite.id, {
+      name: "anthropic-items",
+      items: anthropicSimpleSequence,
+    });
+
+    const response = await authenticatedFetch(
+      managementUrl(`/orgs/${org.id}/suites/${suite.id}/tests/${test.id}`),
+      {
+        method: "PATCH",
+        ...jsonRequest({ items: anthropicToolSequence }),
+      },
+      admin
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.items).toHaveLength(anthropicToolSequence.length);
+    expect(body.items[0].type).toBe("anthropic_system");
+  });
+
+  it("rejects openai items in anthropic suites", async () => {
+    const admin = await createTestUser();
+    const { body: org } = await createOrg(admin);
+    const { body: suite } = await createSuite(admin, org.id, {
+      name: "anthropic-reject-openai",
+      protocol: "anthropic",
+    });
+
+    const { response, body } = await createTest(admin, org.id, suite.id, {
+      name: "openai-items",
+      items: simpleMessageSequence,
+    });
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatchObject({ code: "invalid_request" });
+  });
+
+  it("rejects anthropic items in openai suites", async () => {
+    const admin = await createTestUser();
+    const { body: org } = await createOrg(admin);
+    const { body: suite } = await createSuite(admin, org.id, {
+      name: "openai-reject-anthropic",
+    });
+
+    const { response, body } = await createTest(admin, org.id, suite.id, {
+      name: "anthropic-items",
+      items: anthropicSimpleSequence,
+    });
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatchObject({ code: "invalid_request" });
   });
 
   it("rejects test renames that conflict", async () => {

--- a/src/actions/suites.ts
+++ b/src/actions/suites.ts
@@ -46,7 +46,7 @@ export async function createSuite(
         orgId,
         name: parsed.data.name,
         description: parsed.data.description,
-        protocol: parsed.data.protocol ?? "openai",
+        protocol: parsed.data.protocol,
       },
     });
 

--- a/src/actions/suites.ts
+++ b/src/actions/suites.ts
@@ -32,6 +32,7 @@ export async function createSuite(
   const parsed = CreateSuiteSchema.safeParse({
     name: getFormValue(formData, "name"),
     description: getFormValue(formData, "description"),
+    protocol: getFormValue(formData, "protocol"),
   });
 
   if (!parsed.success) {
@@ -45,6 +46,7 @@ export async function createSuite(
         orgId,
         name: parsed.data.name,
         description: parsed.data.description,
+        protocol: parsed.data.protocol ?? "openai",
       },
     });
 

--- a/src/actions/tests.ts
+++ b/src/actions/tests.ts
@@ -8,7 +8,12 @@ import { getFormValue, requireMembership } from "@/actions/helpers";
 import type { ActionResult } from "@/actions/types";
 import { prisma } from "@/lib/prisma";
 import { findSuiteOrNull, findTestOrNull } from "@/lib/test-helpers";
-import { CreateTestSchema, UpdateTestSchema } from "@/lib/schemas/test-items";
+import {
+  CreateAnthropicTestSchema,
+  CreateTestSchema,
+  UpdateAnthropicTestSchema,
+  UpdateTestSchema,
+} from "@/lib/schemas/test-items";
 
 function parseItems(raw: string | undefined) {
   if (!raw) {
@@ -52,7 +57,11 @@ export async function createTest(
     return { success: false, error: itemsResult.error };
   }
 
-  const parsed = CreateTestSchema.safeParse({
+  const createSchema =
+    suite.protocol === "anthropic"
+      ? CreateAnthropicTestSchema
+      : CreateTestSchema;
+  const parsed = createSchema.safeParse({
     name: getFormValue(formData, "name"),
     description: getFormValue(formData, "description"),
     items: itemsResult.value,
@@ -73,7 +82,7 @@ export async function createTest(
           create: parsed.data.items.map((item, index) => ({
             position: index,
             type: item.type,
-            content: item.content,
+            content: item.content as Prisma.InputJsonValue,
           })),
         },
       },
@@ -130,7 +139,11 @@ export async function updateTest(
     return { success: false, error: itemsResult.error };
   }
 
-  const parsed = UpdateTestSchema.safeParse({
+  const updateSchema =
+    test.testSuite.protocol === "anthropic"
+      ? UpdateAnthropicTestSchema
+      : UpdateTestSchema;
+  const parsed = updateSchema.safeParse({
     name: getFormValue(formData, "name"),
     description: getFormValue(formData, "description"),
     items: itemsResult.value,
@@ -169,7 +182,7 @@ export async function updateTest(
                 create: parsed.data.items.map((item, index) => ({
                   position: index,
                   type: item.type,
-                  content: item.content,
+                  content: item.content as Prisma.InputJsonValue,
                 })),
               },
             }

--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/page.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/page.tsx
@@ -8,6 +8,7 @@ import { ExportSuiteButton } from "@/components/export-suite-button";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -47,7 +48,13 @@ export default async function SuiteDetailPage({
     include: { _count: { select: { items: true } } },
   });
 
-  const endpoint = `https://testllm.dev/v1/org/${suite.org.slug}/suite/${suite.name}/responses`;
+  const protocolLabel = suite.protocol === "anthropic" ? "Anthropic" : "OpenAI";
+  const endpointPath = suite.protocol === "anthropic" ? "messages" : "responses";
+  const endpointTitle =
+    suite.protocol === "anthropic"
+      ? "Messages API Endpoint"
+      : "Responses API Endpoint";
+  const endpoint = `https://testllm.dev/v1/org/${suite.org.slug}/suite/${suite.name}/${endpointPath}`;
 
   return (
     <div className="space-y-6">
@@ -85,6 +92,10 @@ export default async function SuiteDetailPage({
           </div>
         }
       />
+
+      <div>
+        <Badge variant="secondary">{protocolLabel}</Badge>
+      </div>
 
       <div className="space-y-4">
         <div className="flex items-center justify-between gap-4">
@@ -143,7 +154,7 @@ export default async function SuiteDetailPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>Responses API Endpoint</CardTitle>
+          <CardTitle>{endpointTitle}</CardTitle>
           <CardDescription>
             Use this endpoint when configuring your agent.
           </CardDescription>

--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/page.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/page.tsx
@@ -25,6 +25,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { prisma } from "@/lib/prisma";
+import { getProtocolMeta } from "@/lib/protocols";
 
 export default async function SuiteDetailPage({
   params,
@@ -48,12 +49,8 @@ export default async function SuiteDetailPage({
     include: { _count: { select: { items: true } } },
   });
 
-  const protocolLabel = suite.protocol === "anthropic" ? "Anthropic" : "OpenAI";
-  const endpointPath = suite.protocol === "anthropic" ? "messages" : "responses";
-  const endpointTitle =
-    suite.protocol === "anthropic"
-      ? "Messages API Endpoint"
-      : "Responses API Endpoint";
+  const { label: protocolLabel, endpointPath, endpointTitle } =
+    getProtocolMeta(suite.protocol);
   const endpoint = `https://testllm.dev/v1/org/${suite.org.slug}/suite/${suite.name}/${endpointPath}`;
 
   return (

--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/edit/form.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/edit/form.tsx
@@ -18,6 +18,7 @@ type EditTestFormProps = {
   name: string;
   description: string | null;
   items: TestItemDraft[];
+  protocol: "openai" | "anthropic";
 };
 
 export function EditTestForm({
@@ -27,6 +28,7 @@ export function EditTestForm({
   name,
   description,
   items,
+  protocol,
 }: EditTestFormProps) {
   const [state, formAction, pending] = useActionState(
     updateTest,
@@ -53,7 +55,11 @@ export function EditTestForm({
       </div>
       <div className="space-y-3">
         <Label>Conversation Items</Label>
-        <TestItemEditor inputName="items" initialItems={items} />
+        <TestItemEditor
+          inputName="items"
+          initialItems={items}
+          protocol={protocol}
+        />
       </div>
       {state?.success === false && state.error ? (
         <p className="text-sm text-destructive">{state.error}</p>

--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/edit/page.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/edit/page.tsx
@@ -50,6 +50,7 @@ export default async function EditTestPage({
         name={test.name}
         description={test.description}
         items={initialItems}
+        protocol={test.testSuite.protocol}
       />
     </div>
   );

--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/page.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/page.tsx
@@ -36,7 +36,9 @@ export default async function TestDetailPage({
   });
 
   const listItems = mapPrismaItemsToListItems(items);
-  const endpoint = `https://testllm.dev/v1/org/${test.testSuite.org.slug}/suite/${test.testSuite.name}/responses`;
+  const endpointPath =
+    test.testSuite.protocol === "anthropic" ? "messages" : "responses";
+  const endpoint = `https://testllm.dev/v1/org/${test.testSuite.org.slug}/suite/${test.testSuite.name}/${endpointPath}`;
 
   return (
     <div className="space-y-6">

--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/page.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/[testId]/page.tsx
@@ -15,6 +15,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { prisma } from "@/lib/prisma";
+import { getProtocolMeta } from "@/lib/protocols";
 import { findTestOrNull } from "@/lib/test-helpers";
 import { mapPrismaItemsToListItems } from "@/lib/test-item-mappers";
 
@@ -36,8 +37,7 @@ export default async function TestDetailPage({
   });
 
   const listItems = mapPrismaItemsToListItems(items);
-  const endpointPath =
-    test.testSuite.protocol === "anthropic" ? "messages" : "responses";
+  const { endpointPath } = getProtocolMeta(test.testSuite.protocol);
   const endpoint = `https://testllm.dev/v1/org/${test.testSuite.org.slug}/suite/${test.testSuite.name}/${endpointPath}`;
 
   return (

--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/new/form.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/new/form.tsx
@@ -13,9 +13,14 @@ import { Textarea } from "@/components/ui/textarea";
 type CreateTestFormProps = {
   orgId: string;
   suiteId: string;
+  protocol: "openai" | "anthropic";
 };
 
-export function CreateTestForm({ orgId, suiteId }: CreateTestFormProps) {
+export function CreateTestForm({
+  orgId,
+  suiteId,
+  protocol,
+}: CreateTestFormProps) {
   const [state, formAction, pending] = useActionState(
     createTest,
     null
@@ -40,7 +45,7 @@ export function CreateTestForm({ orgId, suiteId }: CreateTestFormProps) {
       </div>
       <div className="space-y-3">
         <Label>Conversation Items</Label>
-        <TestItemEditor inputName="items" />
+        <TestItemEditor inputName="items" protocol={protocol} />
       </div>
       {state?.success === false && state.error ? (
         <p className="text-sm text-destructive">{state.error}</p>

--- a/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/new/page.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/[suiteId]/tests/new/page.tsx
@@ -36,7 +36,11 @@ export default async function NewTestPage({
         title="Create Test"
         description="Define a deterministic conversation sequence."
       />
-      <CreateTestForm orgId={orgId} suiteId={suiteId} />
+      <CreateTestForm
+        orgId={orgId}
+        suiteId={suiteId}
+        protocol={suite.protocol}
+      />
     </div>
   );
 }

--- a/src/app/(auth)/orgs/[orgId]/suites/new/form.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/new/form.tsx
@@ -7,6 +7,13 @@ import { createSuite } from "@/actions/suites";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 
 type CreateSuiteFormProps = {
@@ -14,6 +21,9 @@ type CreateSuiteFormProps = {
 };
 
 export function CreateSuiteForm({ orgId }: CreateSuiteFormProps) {
+  const [protocol, setProtocol] = React.useState<"openai" | "anthropic">(
+    "openai"
+  );
   const [state, formAction, pending] = useActionState(
     createSuite,
     null
@@ -39,6 +49,24 @@ export function CreateSuiteForm({ orgId }: CreateSuiteFormProps) {
           placeholder="Weather agent test scenarios"
           className="min-h-[110px]"
         />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="suite-protocol">Protocol</Label>
+        <Select
+          value={protocol}
+          onValueChange={(value) =>
+            setProtocol(value as "openai" | "anthropic")
+          }
+        >
+          <SelectTrigger id="suite-protocol" className="w-full">
+            <SelectValue placeholder="Select protocol" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="openai">OpenAI</SelectItem>
+            <SelectItem value="anthropic">Anthropic</SelectItem>
+          </SelectContent>
+        </Select>
+        <input name="protocol" type="hidden" value={protocol} />
       </div>
       {state?.success === false && state.error ? (
         <p className="text-sm text-destructive">{state.error}</p>

--- a/src/app/(auth)/orgs/[orgId]/suites/page.tsx
+++ b/src/app/(auth)/orgs/[orgId]/suites/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -52,6 +53,7 @@ export default async function SuitesPage({
             <TableRow>
               <TableHead>Name</TableHead>
               <TableHead>Description</TableHead>
+              <TableHead>Protocol</TableHead>
               <TableHead className="text-right">Tests</TableHead>
             </TableRow>
           </TableHeader>
@@ -68,6 +70,11 @@ export default async function SuitesPage({
                 </TableCell>
                 <TableCell className="max-w-[360px] truncate text-muted-foreground">
                   {suite.description || "—"}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="secondary">
+                    {suite.protocol === "anthropic" ? "Anthropic" : "OpenAI"}
+                  </Badge>
                 </TableCell>
                 <TableCell className="text-right">
                   {suite._count.tests}

--- a/src/components/test-item-editor/item-content-fields.tsx
+++ b/src/components/test-item-editor/item-content-fields.tsx
@@ -47,6 +47,21 @@ function isMessageBlocks(
   return Array.isArray(content);
 }
 
+function isContentBlock(value: unknown): value is AnthropicContentBlock {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  if (record.type === "text") {
+    return typeof record.text === "string";
+  }
+  if (record.type === "tool_use") {
+    return typeof record.id === "string" && typeof record.name === "string";
+  }
+  if (record.type === "tool_result") {
+    return typeof record.tool_use_id === "string";
+  }
+  return false;
+}
+
 function blocksToText(blocks: AnthropicContentBlock[]) {
   if (!blocks.every(isTextBlock)) return null;
   return blocks.map((block) => block.text).join("\n");
@@ -56,7 +71,10 @@ function parseBlocksInput(value: string) {
   if (!value.trim()) return [] as AnthropicContentBlock[];
   try {
     const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? (parsed as AnthropicContentBlock[]) : null;
+    if (!Array.isArray(parsed)) return null;
+    const blocks = parsed.filter(isContentBlock);
+    if (blocks.length !== parsed.length) return null;
+    return blocks;
   } catch {
     return null;
   }
@@ -69,31 +87,39 @@ function stringifyBlocks(blocks: AnthropicContentBlock[]) {
 export function ItemContentFields({ item, onChange }: ItemContentFieldsProps) {
   const [systemBlocksValue, setSystemBlocksValue] = React.useState(() => {
     if (item.type !== "anthropic_system") return "";
-    if ("blocks" in item.content) return stringifyBlocks(item.content.blocks);
+    if (hasSystemBlocks(item.content)) {
+      return stringifyBlocks(item.content.blocks);
+    }
     return stringifyBlocks(textToBlocks(item.content.text));
   });
 
   const [messageBlocksValue, setMessageBlocksValue] = React.useState(() => {
     if (item.type !== "anthropic_message") return "";
-    if (Array.isArray(item.content.content)) {
+    if (isMessageBlocks(item.content.content)) {
       return stringifyBlocks(item.content.content);
     }
     return stringifyBlocks(textToBlocks(item.content.content));
   });
 
-  React.useEffect(() => {
-    if (item.type !== "anthropic_system") return;
-    if ("blocks" in item.content) {
-      setSystemBlocksValue(stringifyBlocks(item.content.blocks));
-    }
-  }, [item]);
+  const systemBlocks =
+    item.type === "anthropic_system" && hasSystemBlocks(item.content)
+      ? item.content.blocks
+      : null;
+
+  const messageBlocks =
+    item.type === "anthropic_message" && isMessageBlocks(item.content.content)
+      ? item.content.content
+      : null;
 
   React.useEffect(() => {
-    if (item.type !== "anthropic_message") return;
-    if (Array.isArray(item.content.content)) {
-      setMessageBlocksValue(stringifyBlocks(item.content.content));
-    }
-  }, [item]);
+    if (!systemBlocks) return;
+    setSystemBlocksValue(stringifyBlocks(systemBlocks));
+  }, [systemBlocks]);
+
+  React.useEffect(() => {
+    if (!messageBlocks) return;
+    setMessageBlocksValue(stringifyBlocks(messageBlocks));
+  }, [messageBlocks]);
 
   if (item.type === "message") {
     const wildcardDisabled = item.content.role === "assistant";

--- a/src/components/test-item-editor/item-content-fields.tsx
+++ b/src/components/test-item-editor/item-content-fields.tsx
@@ -13,6 +13,10 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import type {
+  AnthropicContentBlock,
+  AnthropicMessageContent,
+  AnthropicSystemContent,
+  AnthropicTextBlock,
   MessageContent,
   TestItemDraft,
 } from "@/components/test-item-editor/types";
@@ -22,7 +26,75 @@ type ItemContentFieldsProps = {
   onChange: (item: TestItemDraft) => void;
 };
 
+function textToBlocks(text: string) {
+  if (!text) return [] as AnthropicContentBlock[];
+  return [{ type: "text", text }] as AnthropicContentBlock[];
+}
+
+function isTextBlock(block: AnthropicContentBlock): block is AnthropicTextBlock {
+  return block.type === "text";
+}
+
+function hasSystemBlocks(
+  content: AnthropicSystemContent
+): content is { blocks: AnthropicContentBlock[] } {
+  return "blocks" in content;
+}
+
+function isMessageBlocks(
+  content: AnthropicMessageContent["content"]
+): content is AnthropicContentBlock[] {
+  return Array.isArray(content);
+}
+
+function blocksToText(blocks: AnthropicContentBlock[]) {
+  if (!blocks.every(isTextBlock)) return null;
+  return blocks.map((block) => block.text).join("\n");
+}
+
+function parseBlocksInput(value: string) {
+  if (!value.trim()) return [] as AnthropicContentBlock[];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as AnthropicContentBlock[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringifyBlocks(blocks: AnthropicContentBlock[]) {
+  return JSON.stringify(blocks, null, 2);
+}
+
 export function ItemContentFields({ item, onChange }: ItemContentFieldsProps) {
+  const [systemBlocksValue, setSystemBlocksValue] = React.useState(() => {
+    if (item.type !== "anthropic_system") return "";
+    if ("blocks" in item.content) return stringifyBlocks(item.content.blocks);
+    return stringifyBlocks(textToBlocks(item.content.text));
+  });
+
+  const [messageBlocksValue, setMessageBlocksValue] = React.useState(() => {
+    if (item.type !== "anthropic_message") return "";
+    if (Array.isArray(item.content.content)) {
+      return stringifyBlocks(item.content.content);
+    }
+    return stringifyBlocks(textToBlocks(item.content.content));
+  });
+
+  React.useEffect(() => {
+    if (item.type !== "anthropic_system") return;
+    if ("blocks" in item.content) {
+      setSystemBlocksValue(stringifyBlocks(item.content.blocks));
+    }
+  }, [item]);
+
+  React.useEffect(() => {
+    if (item.type !== "anthropic_message") return;
+    if (Array.isArray(item.content.content)) {
+      setMessageBlocksValue(stringifyBlocks(item.content.content));
+    }
+  }, [item]);
+
   if (item.type === "message") {
     const wildcardDisabled = item.content.role === "assistant";
     const anyRole = !wildcardDisabled && Boolean(item.content.any_role);
@@ -124,6 +196,205 @@ export function ItemContentFields({ item, onChange }: ItemContentFieldsProps) {
             placeholder="Message content"
             className="min-h-[90px]"
           />
+        </div>
+      </div>
+    );
+  }
+
+  if (item.type === "anthropic_system") {
+    let blocks: AnthropicContentBlock[] = [];
+    let usesBlocks = false;
+    let textValue = "";
+
+    if (hasSystemBlocks(item.content)) {
+      usesBlocks = true;
+      blocks = item.content.blocks;
+    } else {
+      textValue = item.content.text;
+      blocks = textToBlocks(item.content.text);
+    }
+    const canSwitchToText = blocksToText(blocks) !== null;
+    const toggleId = `${item.clientId}-system-json`;
+
+    return (
+      <div className="grid gap-3">
+        <div className="flex items-center justify-between">
+          <Label>System Prompt</Label>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id={toggleId}
+              checked={usesBlocks}
+              disabled={usesBlocks && !canSwitchToText}
+              onCheckedChange={(checked) => {
+                if (checked) {
+                  setSystemBlocksValue(stringifyBlocks(blocks));
+                  onChange({
+                    ...item,
+                    content: { blocks },
+                  });
+                  return;
+                }
+                const textValue = blocksToText(blocks);
+                if (textValue === null) return;
+                onChange({
+                  ...item,
+                  content: { text: textValue },
+                });
+              }}
+            />
+            <Label htmlFor={toggleId} className="text-xs text-muted-foreground">
+              JSON
+            </Label>
+          </div>
+        </div>
+        {usesBlocks ? (
+          <Textarea
+            value={systemBlocksValue}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              setSystemBlocksValue(nextValue);
+              const parsed = parseBlocksInput(nextValue);
+              if (!parsed) return;
+              onChange({
+                ...item,
+                content: { blocks: parsed },
+              });
+            }}
+            placeholder='[{"type":"text","text":"System prompt"}]'
+            className="min-h-[110px] font-mono"
+          />
+        ) : (
+          <Textarea
+            value={textValue}
+            onChange={(event) =>
+              onChange({
+                ...item,
+                content: { text: event.target.value },
+              })
+            }
+            placeholder="System prompt"
+            className="min-h-[90px]"
+          />
+        )}
+      </div>
+    );
+  }
+
+  if (item.type === "anthropic_message") {
+    let blocks: AnthropicContentBlock[] = [];
+    let usesBlocks = false;
+
+    if (isMessageBlocks(item.content.content)) {
+      usesBlocks = true;
+      blocks = item.content.content;
+    } else {
+      blocks = textToBlocks(item.content.content);
+    }
+    const canSwitchToText = blocksToText(blocks) !== null;
+    const toggleId = `${item.clientId}-message-json`;
+
+    return (
+      <div className="grid gap-3">
+        <div className="grid gap-2 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label>Role</Label>
+            <Select
+              value={item.content.role}
+              onValueChange={(value) =>
+                onChange({
+                  ...item,
+                  content: {
+                    ...item.content,
+                    role: value as AnthropicMessageContent["role"],
+                  },
+                })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select role" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="user">user</SelectItem>
+                <SelectItem value="assistant">assistant</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label>Content</Label>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id={toggleId}
+                checked={usesBlocks}
+                disabled={usesBlocks && !canSwitchToText}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    setMessageBlocksValue(stringifyBlocks(blocks));
+                    onChange({
+                      ...item,
+                      content: {
+                        ...item.content,
+                        content: blocks,
+                      },
+                    });
+                    return;
+                  }
+                  const textValue = blocksToText(blocks);
+                  if (textValue === null) return;
+                  onChange({
+                    ...item,
+                    content: {
+                      ...item.content,
+                      content: textValue,
+                    },
+                  });
+                }}
+              />
+              <Label htmlFor={toggleId} className="text-xs text-muted-foreground">
+                JSON
+              </Label>
+            </div>
+          </div>
+          {usesBlocks ? (
+            <Textarea
+              value={messageBlocksValue}
+              onChange={(event) => {
+                const nextValue = event.target.value;
+                setMessageBlocksValue(nextValue);
+                const parsed = parseBlocksInput(nextValue);
+                if (!parsed) return;
+                onChange({
+                  ...item,
+                  content: {
+                    ...item.content,
+                    content: parsed,
+                  },
+                });
+              }}
+              placeholder='[{"type":"text","text":"Message"}]'
+              className="min-h-[120px] font-mono"
+            />
+          ) : (
+            <Textarea
+              value={
+                typeof item.content.content === "string"
+                  ? item.content.content
+                  : ""
+              }
+              onChange={(event) =>
+                onChange({
+                  ...item,
+                  content: {
+                    ...item.content,
+                    content: event.target.value,
+                  },
+                })
+              }
+              placeholder="Message content"
+              className="min-h-[90px]"
+            />
+          )}
         </div>
       </div>
     );

--- a/src/components/test-item-editor/test-item-editor.tsx
+++ b/src/components/test-item-editor/test-item-editor.tsx
@@ -9,7 +9,7 @@ import type { TestItemDraft } from "@/components/test-item-editor/types";
 type TestItemEditorProps = {
   initialItems?: TestItemDraft[];
   inputName: string;
-  protocol?: "openai" | "anthropic";
+  protocol: "openai" | "anthropic";
 };
 
 function createMessageItem(): TestItemDraft {
@@ -55,7 +55,7 @@ function createAnthropicMessageItem(): TestItemDraft {
 export function TestItemEditor({
   initialItems,
   inputName,
-  protocol = "openai",
+  protocol,
 }: TestItemEditorProps) {
   const [items, setItems] = React.useState<TestItemDraft[]>(() => {
     if (initialItems && initialItems.length > 0) return initialItems;

--- a/src/components/test-item-editor/test-item-editor.tsx
+++ b/src/components/test-item-editor/test-item-editor.tsx
@@ -9,6 +9,7 @@ import type { TestItemDraft } from "@/components/test-item-editor/types";
 type TestItemEditorProps = {
   initialItems?: TestItemDraft[];
   inputName: string;
+  protocol?: "openai" | "anthropic";
 };
 
 function createMessageItem(): TestItemDraft {
@@ -35,12 +36,32 @@ function createFunctionCallOutputItem(): TestItemDraft {
   };
 }
 
+function createAnthropicSystemItem(): TestItemDraft {
+  return {
+    type: "anthropic_system",
+    clientId: crypto.randomUUID(),
+    content: { text: "" },
+  };
+}
+
+function createAnthropicMessageItem(): TestItemDraft {
+  return {
+    type: "anthropic_message",
+    clientId: crypto.randomUUID(),
+    content: { role: "user", content: "" },
+  };
+}
+
 export function TestItemEditor({
   initialItems,
   inputName,
+  protocol = "openai",
 }: TestItemEditorProps) {
   const [items, setItems] = React.useState<TestItemDraft[]>(() => {
     if (initialItems && initialItems.length > 0) return initialItems;
+    if (protocol === "anthropic") {
+      return [createAnthropicMessageItem()];
+    }
     return [createMessageItem()];
   });
 
@@ -87,6 +108,7 @@ export function TestItemEditor({
           isFirst={index === 0}
           isLast={index === items.length - 1}
           disableRemove={items.length === 1}
+          protocol={protocol}
           onChange={(updated) => updateItem(index, updated)}
           onMoveUp={() => moveItem(index, index - 1)}
           onMoveDown={() => moveItem(index, index + 1)}
@@ -95,34 +117,63 @@ export function TestItemEditor({
       ))}
 
       <div className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => setItems((current) => [...current, createMessageItem()])}
-        >
-          <Plus className="size-4" /> Add Message
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() =>
-            setItems((current) => [...current, createFunctionCallItem()])
-          }
-        >
-          <Plus className="size-4" /> Add Function Call
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() =>
-            setItems((current) => [...current, createFunctionCallOutputItem()])
-          }
-        >
-          <Plus className="size-4" /> Add Output
-        </Button>
+        {protocol === "anthropic" ? (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setItems((current) => [...current, createAnthropicSystemItem()])
+              }
+            >
+              <Plus className="size-4" /> Add System Prompt
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setItems((current) => [...current, createAnthropicMessageItem()])
+              }
+            >
+              <Plus className="size-4" /> Add Message
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setItems((current) => [...current, createMessageItem()])
+              }
+            >
+              <Plus className="size-4" /> Add Message
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setItems((current) => [...current, createFunctionCallItem()])
+              }
+            >
+              <Plus className="size-4" /> Add Function Call
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setItems((current) => [...current, createFunctionCallOutputItem()])
+              }
+            >
+              <Plus className="size-4" /> Add Output
+            </Button>
+          </>
+        )}
       </div>
 
       <input name={inputName} type="hidden" value={serializedItems} />

--- a/src/components/test-item-editor/test-item-row.tsx
+++ b/src/components/test-item-editor/test-item-row.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { ItemContentFields } from "@/components/test-item-editor/item-content-fields";
+import { getTestItemDirection } from "@/components/test-item-editor/utils";
 import type { TestItemDraft } from "@/components/test-item-editor/types";
 
 type TestItemRowProps = {
@@ -32,17 +33,6 @@ type TestItemRowProps = {
   onMoveDown: () => void;
   onRemove: () => void;
 };
-
-function getDirection(item: TestItemDraft) {
-  if (item.type === "message") {
-    return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
-  }
-  if (item.type === "anthropic_system") return "INPUT";
-  if (item.type === "anthropic_message") {
-    return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
-  }
-  return item.type === "function_call" ? "OUTPUT" : "INPUT";
-}
 
 function getDefaultContent(type: TestItemDraft["type"]): TestItemDraft {
   const clientId = crypto.randomUUID();
@@ -74,11 +64,15 @@ function getDefaultContent(type: TestItemDraft["type"]): TestItemDraft {
       content: { text: "" },
     };
   }
-  return {
-    type,
-    clientId,
-    content: { role: "user", content: "" },
-  };
+  if (type === "anthropic_message") {
+    return {
+      type,
+      clientId,
+      content: { role: "user", content: "" },
+    };
+  }
+  const _exhaustive: never = type;
+  throw new Error(`Unsupported item type: ${_exhaustive}`);
 }
 
 export function TestItemRow({
@@ -93,7 +87,7 @@ export function TestItemRow({
   onMoveDown,
   onRemove,
 }: TestItemRowProps) {
-  const direction = getDirection(item);
+  const direction = getTestItemDirection(item);
 
   const borderClass =
     direction === "INPUT" ? "border-l-blue-500" : "border-l-emerald-500";

--- a/src/components/test-item-editor/test-item-row.tsx
+++ b/src/components/test-item-editor/test-item-row.tsx
@@ -26,6 +26,7 @@ type TestItemRowProps = {
   isFirst: boolean;
   isLast: boolean;
   disableRemove: boolean;
+  protocol: "openai" | "anthropic";
   onChange: (item: TestItemDraft) => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
@@ -34,6 +35,10 @@ type TestItemRowProps = {
 
 function getDirection(item: TestItemDraft) {
   if (item.type === "message") {
+    return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
+  }
+  if (item.type === "anthropic_system") return "INPUT";
+  if (item.type === "anthropic_message") {
     return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
   }
   return item.type === "function_call" ? "OUTPUT" : "INPUT";
@@ -55,10 +60,24 @@ function getDefaultContent(type: TestItemDraft["type"]): TestItemDraft {
       content: { call_id: "", name: "", arguments: "" },
     };
   }
+  if (type === "function_call_output") {
+    return {
+      type,
+      clientId,
+      content: { call_id: "", output: "" },
+    };
+  }
+  if (type === "anthropic_system") {
+    return {
+      type,
+      clientId,
+      content: { text: "" },
+    };
+  }
   return {
     type,
     clientId,
-    content: { call_id: "", output: "" },
+    content: { role: "user", content: "" },
   };
 }
 
@@ -68,6 +87,7 @@ export function TestItemRow({
   isFirst,
   isLast,
   disableRemove,
+  protocol,
   onChange,
   onMoveUp,
   onMoveDown,
@@ -126,11 +146,24 @@ export function TestItemRow({
               <SelectValue placeholder="Select type" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="message">message</SelectItem>
-              <SelectItem value="function_call">function_call</SelectItem>
-              <SelectItem value="function_call_output">
-                function_call_output
-              </SelectItem>
+              {protocol === "anthropic" ? (
+                <>
+                  <SelectItem value="anthropic_system">
+                    anthropic_system
+                  </SelectItem>
+                  <SelectItem value="anthropic_message">
+                    anthropic_message
+                  </SelectItem>
+                </>
+              ) : (
+                <>
+                  <SelectItem value="message">message</SelectItem>
+                  <SelectItem value="function_call">function_call</SelectItem>
+                  <SelectItem value="function_call_output">
+                    function_call_output
+                  </SelectItem>
+                </>
+              )}
             </SelectContent>
           </Select>
         </div>

--- a/src/components/test-item-editor/types.ts
+++ b/src/components/test-item-editor/types.ts
@@ -1,3 +1,5 @@
+import type { Prisma } from "@prisma/client";
+
 export type MessageContent = {
   role: "user" | "system" | "developer" | "assistant";
   content: string;
@@ -17,12 +19,54 @@ export type FunctionCallOutputContent = {
   output: string;
 };
 
+export type AnthropicTextBlock = {
+  type: "text";
+  text: string;
+};
+
+export type AnthropicToolUseBlock = {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Prisma.InputJsonValue;
+};
+
+export type AnthropicToolResultBlock = {
+  type: "tool_result";
+  tool_use_id: string;
+  content: Prisma.InputJsonValue;
+};
+
+export type AnthropicContentBlock =
+  | AnthropicTextBlock
+  | AnthropicToolUseBlock
+  | AnthropicToolResultBlock;
+
+export type AnthropicSystemContent =
+  | { text: string }
+  | { blocks: AnthropicContentBlock[] };
+
+export type AnthropicMessageContent = {
+  role: "user" | "assistant";
+  content: string | AnthropicContentBlock[];
+};
+
 export type TestItemDraft =
   | { type: "message"; content: MessageContent; clientId: string }
   | { type: "function_call"; content: FunctionCallContent; clientId: string }
   | {
       type: "function_call_output";
       content: FunctionCallOutputContent;
+      clientId: string;
+    }
+  | {
+      type: "anthropic_system";
+      content: AnthropicSystemContent;
+      clientId: string;
+    }
+  | {
+      type: "anthropic_message";
+      content: AnthropicMessageContent;
       clientId: string;
     };
 
@@ -33,4 +77,10 @@ export type TestItemListItem =
       id?: string;
       type: "function_call_output";
       content: FunctionCallOutputContent;
+    }
+  | { id?: string; type: "anthropic_system"; content: AnthropicSystemContent }
+  | {
+      id?: string;
+      type: "anthropic_message";
+      content: AnthropicMessageContent;
     };

--- a/src/components/test-item-editor/utils.ts
+++ b/src/components/test-item-editor/utils.ts
@@ -1,0 +1,29 @@
+import type {
+  TestItemDraft,
+  TestItemListItem,
+} from "@/components/test-item-editor/types";
+
+export type TestItemDirection = "INPUT" | "OUTPUT";
+
+type TestItem = TestItemDraft | TestItemListItem;
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported test item type: ${String(value)}`);
+}
+
+export function getTestItemDirection(item: TestItem): TestItemDirection {
+  switch (item.type) {
+    case "message":
+      return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
+    case "anthropic_system":
+      return "INPUT";
+    case "anthropic_message":
+      return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
+    case "function_call":
+      return "OUTPUT";
+    case "function_call_output":
+      return "INPUT";
+    default:
+      return assertNever(item);
+  }
+}

--- a/src/components/test-item-list.tsx
+++ b/src/components/test-item-list.tsx
@@ -6,6 +6,7 @@ import type {
   AnthropicContentBlock,
   TestItemListItem,
 } from "@/components/test-item-editor/types";
+import { getTestItemDirection } from "@/components/test-item-editor/utils";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
@@ -83,17 +84,6 @@ function renderBlocks(blocks: AnthropicContentBlock[]) {
   );
 }
 
-function getDirection(item: TestItemListItem) {
-  if (item.type === "message") {
-    return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
-  }
-  if (item.type === "anthropic_system") return "INPUT";
-  if (item.type === "anthropic_message") {
-    return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
-  }
-  return item.type === "function_call" ? "OUTPUT" : "INPUT";
-}
-
 function getPreview(item: TestItemListItem) {
   if (item.type === "message") {
     return item.content.any_content ? "<any content>" : item.content.content;
@@ -138,7 +128,7 @@ export function TestItemList({ items }: TestItemListProps) {
       {items.map((item, index) => {
         const id = item.id ?? `${index}`;
         const expanded = openId === id;
-        const direction = getDirection(item);
+        const direction = getTestItemDirection(item);
         const preview = getPreview(item);
         const metaLabel = getMetaLabel(item);
 

--- a/src/components/test-item-list.tsx
+++ b/src/components/test-item-list.tsx
@@ -2,7 +2,10 @@
 
 import * as React from "react";
 import { ChevronDown } from "lucide-react";
-import type { TestItemListItem } from "@/components/test-item-editor/types";
+import type {
+  AnthropicContentBlock,
+  TestItemListItem,
+} from "@/components/test-item-editor/types";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
@@ -21,8 +24,71 @@ function formatJson(value: string) {
   }
 }
 
+function formatJsonValue(value: unknown) {
+  if (typeof value === "string") {
+    return formatJson(value);
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function summarizeBlocks(blocks: AnthropicContentBlock[]) {
+  return blocks
+    .map((block) => {
+      if (block.type === "text") return block.text;
+      if (block.type === "tool_use") return `tool_use:${block.name}`;
+      return `tool_result:${block.tool_use_id}`;
+    })
+    .join(" ");
+}
+
+function renderBlocks(blocks: AnthropicContentBlock[]) {
+  return (
+    <div className="space-y-3">
+      {blocks.map((block, index) => {
+        if (block.type === "text") {
+          return (
+            <div key={`${block.type}-${index}`} className="whitespace-pre-wrap">
+              {block.text}
+            </div>
+          );
+        }
+        if (block.type === "tool_use") {
+          return (
+            <div key={`${block.type}-${index}`} className="space-y-2">
+              <p className="text-xs text-muted-foreground">
+                Tool use: {block.name} ({block.id})
+              </p>
+              <pre className="whitespace-pre-wrap rounded-md bg-background p-3 text-xs">
+                {formatJsonValue(block.input)}
+              </pre>
+            </div>
+          );
+        }
+        return (
+          <div key={`${block.type}-${index}`} className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              Tool result: {block.tool_use_id}
+            </p>
+            <pre className="whitespace-pre-wrap rounded-md bg-background p-3 text-xs">
+              {formatJsonValue(block.content)}
+            </pre>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function getDirection(item: TestItemListItem) {
   if (item.type === "message") {
+    return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
+  }
+  if (item.type === "anthropic_system") return "INPUT";
+  if (item.type === "anthropic_message") {
     return item.content.role === "assistant" ? "OUTPUT" : "INPUT";
   }
   return item.type === "function_call" ? "OUTPUT" : "INPUT";
@@ -31,6 +97,16 @@ function getDirection(item: TestItemListItem) {
 function getPreview(item: TestItemListItem) {
   if (item.type === "message") {
     return item.content.any_content ? "<any content>" : item.content.content;
+  }
+  if (item.type === "anthropic_system") {
+    return "text" in item.content
+      ? item.content.text
+      : summarizeBlocks(item.content.blocks);
+  }
+  if (item.type === "anthropic_message") {
+    return typeof item.content.content === "string"
+      ? item.content.content
+      : summarizeBlocks(item.content.content);
   }
   if (item.type === "function_call") {
     return `${item.content.name}(${item.content.arguments})`;
@@ -41,6 +117,12 @@ function getPreview(item: TestItemListItem) {
 function getMetaLabel(item: TestItemListItem) {
   if (item.type === "message") {
     return item.content.any_role ? "any role" : item.content.role;
+  }
+  if (item.type === "anthropic_system") {
+    return "system";
+  }
+  if (item.type === "anthropic_message") {
+    return item.content.role;
   }
   if (item.type === "function_call") {
     return item.content.name;
@@ -100,6 +182,24 @@ export function TestItemList({ items }: TestItemListProps) {
                       ? "<any content>"
                       : item.content.content}
                   </div>
+                ) : null}
+                {item.type === "anthropic_system" ? (
+                  "text" in item.content ? (
+                    <div className="whitespace-pre-wrap">
+                      {item.content.text}
+                    </div>
+                  ) : (
+                    renderBlocks(item.content.blocks)
+                  )
+                ) : null}
+                {item.type === "anthropic_message" ? (
+                  typeof item.content.content === "string" ? (
+                    <div className="whitespace-pre-wrap">
+                      {item.content.content}
+                    </div>
+                  ) : (
+                    renderBlocks(item.content.content)
+                  )
                 ) : null}
                 {item.type === "function_call" ? (
                   <div className="space-y-2">

--- a/src/lib/protocols.ts
+++ b/src/lib/protocols.ts
@@ -1,0 +1,30 @@
+import type { Protocol } from "@prisma/client";
+
+type ProtocolMeta = {
+  label: string;
+  endpointPath: "responses" | "messages";
+  endpointTitle: string;
+};
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported protocol: ${String(value)}`);
+}
+
+export function getProtocolMeta(protocol: Protocol): ProtocolMeta {
+  switch (protocol) {
+    case "openai":
+      return {
+        label: "OpenAI",
+        endpointPath: "responses",
+        endpointTitle: "Responses API Endpoint",
+      };
+    case "anthropic":
+      return {
+        label: "Anthropic",
+        endpointPath: "messages",
+        endpointTitle: "Messages API Endpoint",
+      };
+    default:
+      return assertNever(protocol);
+  }
+}

--- a/src/lib/test-item-mappers.ts
+++ b/src/lib/test-item-mappers.ts
@@ -1,5 +1,7 @@
 import type { TestItem } from "@prisma/client";
 import type {
+  AnthropicMessageContent,
+  AnthropicSystemContent,
   FunctionCallContent,
   FunctionCallOutputContent,
   MessageContent,
@@ -34,6 +36,20 @@ export function mapPrismaItemsToListItems(
         content: item.content as FunctionCallOutputContent,
       };
     }
+    if (item.type === "anthropic_system") {
+      return {
+        id: item.id,
+        type: "anthropic_system",
+        content: item.content as AnthropicSystemContent,
+      };
+    }
+    if (item.type === "anthropic_message") {
+      return {
+        id: item.id,
+        type: "anthropic_message",
+        content: item.content as AnthropicMessageContent,
+      };
+    }
     throw new Error("Unsupported test item type");
   });
 }
@@ -63,6 +79,20 @@ export function mapPrismaItemsToDrafts(
         clientId,
         type: "function_call_output",
         content: item.content as FunctionCallOutputContent,
+      };
+    }
+    if (item.type === "anthropic_system") {
+      return {
+        clientId,
+        type: "anthropic_system",
+        content: item.content as AnthropicSystemContent,
+      };
+    }
+    if (item.type === "anthropic_message") {
+      return {
+        clientId,
+        type: "anthropic_message",
+        content: item.content as AnthropicMessageContent,
       };
     }
     throw new Error("Unsupported test item type");


### PR DESCRIPTION
## Summary
- add protocol selection and badges/endpoints for suites and tests
- expand test item editor/list/mappers for Anthropic message content blocks
- add protocol-aware suite/test actions and management API e2e coverage

## Testing
- npm run lint
- npm run test
- npm run test:e2e

#49