### PR TITLE
feat(messages): add any_content wildcard

### DIFF
--- a/src/components/test-item-editor/types.ts
+++ b/src/components/test-item-editor/types.ts
@@ -43,12 +43,13 @@ export type AnthropicContentBlock =
   | AnthropicToolResultBlock;
 
 export type AnthropicSystemContent =
-  | { text: string }
-  | { blocks: AnthropicContentBlock[] };
+  | { text: string; any_content?: boolean }
+  | { blocks: AnthropicContentBlock[]; any_content?: boolean };
 
 export type AnthropicMessageContent = {
   role: "user" | "assistant";
   content: string | AnthropicContentBlock[];
+  any_content?: boolean;
 };
 
 export type TestItemDraft =

--- a/src/lib/messages/__tests__/matching.test.ts
+++ b/src/lib/messages/__tests__/matching.test.ts
@@ -4,7 +4,11 @@ import {
   matchInput,
   normalizeRequest,
 } from "@/lib/messages/matching";
-import type { ContentBlock, TestItemRecord } from "@/lib/messages/types";
+import type {
+  ContentBlock,
+  SystemContent,
+  TestItemRecord,
+} from "@/lib/messages/types";
 
 const textBlock = (text: string): ContentBlock => ({ type: "text", text });
 
@@ -30,7 +34,7 @@ const toolResultBlock = (
 
 const systemItem = (
   position: number,
-  content: { text: string } | { blocks: ContentBlock[] }
+  content: SystemContent
 ): TestItemRecord => ({
   id: `sys-${position}`,
   position,
@@ -41,12 +45,13 @@ const systemItem = (
 const messageItem = (
   position: number,
   role: "user" | "assistant",
-  content: string | ContentBlock[]
+  content: string | ContentBlock[],
+  options?: { any_content?: boolean }
 ): TestItemRecord => ({
   id: `msg-${position}`,
   position,
   type: "anthropic_message",
-  content: { role, content },
+  content: { role, content, ...options },
 });
 
 describe("matchInput", () => {
@@ -66,6 +71,38 @@ describe("matchInput", () => {
     if (!isMatchError(result)) {
       expect(result.outputMessage.role).toBe("assistant");
       expect(result.outputMessage.content).toEqual([textBlock("Hi there")]);
+    }
+  });
+
+  it("matches any_content on the system prompt", () => {
+    const sequence = [
+      systemItem(0, { text: "Expected", any_content: true }),
+      messageItem(1, "assistant", "Welcome"),
+    ];
+
+    const input = normalizeRequest("Actual", []);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputMessage.content).toEqual([textBlock("Welcome")]);
+    }
+  });
+
+  it("matches any_content on a user message", () => {
+    const sequence = [
+      messageItem(0, "user", "Expected", { any_content: true }),
+      messageItem(1, "assistant", "Reply"),
+    ];
+
+    const input = normalizeRequest(undefined, [
+      { role: "user", content: "Actual" },
+    ]);
+    const result = matchInput(sequence, input);
+
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputMessage.content).toEqual([textBlock("Reply")]);
     }
   });
 
@@ -110,6 +147,27 @@ describe("matchInput", () => {
       expect(secondResult.outputMessage.content).toEqual([
         textBlock("It is 65F."),
       ]);
+    }
+  });
+
+  it("matches any_content on assistant messages in history", () => {
+    const sequence = [
+      messageItem(0, "user", "Hello"),
+      messageItem(1, "assistant", "Placeholder", { any_content: true }),
+      messageItem(2, "user", "Next"),
+      messageItem(3, "assistant", "Final"),
+    ];
+
+    const input = normalizeRequest(undefined, [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Different" },
+      { role: "user", content: "Next" },
+    ]);
+
+    const result = matchInput(sequence, input);
+    expect(isMatchError(result)).toBe(false);
+    if (!isMatchError(result)) {
+      expect(result.outputMessage.content).toEqual([textBlock("Final")]);
     }
   });
 
@@ -226,7 +284,7 @@ describe("matchInput", () => {
     }
   });
 
-  it("returns input_mismatch when content mismatches", () => {
+  it("returns input_mismatch when content mismatches without any_content", () => {
     const sequence = [
       messageItem(0, "user", "Hello"),
       messageItem(1, "assistant", "Hi"),

--- a/src/lib/messages/matching.ts
+++ b/src/lib/messages/matching.ts
@@ -27,13 +27,18 @@ export const SystemSchema = z.union([
 ]);
 
 const StoredSystemContentSchema = z.union([
-  z.object({ text: z.string() }).passthrough(),
-  z.object({ blocks: z.array(ContentBlockSchema) }).passthrough(),
+  z
+    .object({ text: z.string(), any_content: z.boolean().optional() })
+    .passthrough(),
+  z
+    .object({ blocks: z.array(ContentBlockSchema), any_content: z.boolean().optional() })
+    .passthrough(),
 ]);
 
 const StoredMessageContentSchema = z.object({
   role: z.enum(["user", "assistant"]),
   content: MessageContentSchema,
+  any_content: z.boolean().optional(),
 });
 
 const TestItemRecordSchema = z.discriminatedUnion("type", [
@@ -219,20 +224,24 @@ export function matchInput(
       if (!input.system) {
         return mismatch(item.position, "expected system prompt, got none");
       }
-      const expectedBlocks = normalizeStoredSystem(item);
-      const actualBlocks = input.system.blocks;
-      if (!blocksEqual(expectedBlocks, actualBlocks)) {
-        return mismatch(
-          item.position,
-          `expected system content ${formatBlocks(expectedBlocks)}, ` +
-            `got ${formatBlocks(actualBlocks)}`
-        );
+      const anyContent = item.content.any_content === true;
+      if (!anyContent) {
+        const expectedBlocks = normalizeStoredSystem(item);
+        const actualBlocks = input.system.blocks;
+        if (!blocksEqual(expectedBlocks, actualBlocks)) {
+          return mismatch(
+            item.position,
+            `expected system content ${formatBlocks(expectedBlocks)}, ` +
+              `got ${formatBlocks(actualBlocks)}`
+          );
+        }
       }
       systemMatched = true;
       continue;
     }
 
     const expectedMessage = normalizeStoredMessage(item.content);
+    const anyContent = item.content.any_content === true;
 
     if (expectedMessage.role === "user") {
       if (messageIndex >= input.messages.length) {
@@ -247,7 +256,7 @@ export function matchInput(
         );
       }
 
-      if (!blocksEqual(expectedMessage.content, actual.content)) {
+      if (!anyContent && !blocksEqual(expectedMessage.content, actual.content)) {
         return mismatch(
           item.position,
           `expected content ${formatBlocks(expectedMessage.content)}, ` +
@@ -271,7 +280,7 @@ export function matchInput(
       );
     }
 
-    if (!blocksEqual(expectedMessage.content, actual.content)) {
+    if (!anyContent && !blocksEqual(expectedMessage.content, actual.content)) {
       return mismatch(
         item.position,
         `expected content ${formatBlocks(expectedMessage.content)}, ` +

--- a/src/lib/messages/types.ts
+++ b/src/lib/messages/types.ts
@@ -23,12 +23,13 @@ export interface ToolResultBlock extends Prisma.InputJsonObject {
 export type ContentBlock = TextBlock | ToolUseBlock | ToolResultBlock;
 
 export type SystemContent =
-  | { text: string }
-  | { blocks: ContentBlock[] };
+  | { text: string; any_content?: boolean }
+  | { blocks: ContentBlock[]; any_content?: boolean };
 
 export interface MessageContent {
   role: MessageRole;
   content: string | ContentBlock[];
+  any_content?: boolean;
 }
 
 export interface BaseTestItemRecord {

--- a/src/lib/schemas/test-items.ts
+++ b/src/lib/schemas/test-items.ts
@@ -47,13 +47,18 @@ const TestItemSchema = z.union([
 ]);
 
 const AnthropicSystemContentSchema = z.union([
-  z.object({ text: z.string() }).passthrough(),
-  z.object({ blocks: z.array(ContentBlockSchema) }).passthrough(),
+  z
+    .object({ text: z.string(), any_content: z.boolean().optional() })
+    .passthrough(),
+  z
+    .object({ blocks: z.array(ContentBlockSchema), any_content: z.boolean().optional() })
+    .passthrough(),
 ]);
 
 const AnthropicMessageContentSchema = z.object({
   role: z.enum(["user", "assistant"]),
   content: z.union([z.string(), z.array(ContentBlockSchema)]),
+  any_content: z.boolean().optional(),
 });
 
 const AnthropicSystemItemSchema = z.object({


### PR DESCRIPTION
## Summary
- add any_content support to anthropic message/system schemas and types
- skip content comparison when any_content is set for anthropic messages
- add unit coverage for any_content behavior in message matcher

## Testing
- env $(cat .env.test | xargs) npm run lint
- env $(cat .env.test | xargs) npm run test
- env $(cat .env.test | xargs) npm run build
- env $(cat .env.test | xargs) npm run test:e2e

Ref: #52