### PR TITLE
keep content contains on read

### DIFF
--- a/src/lib/responses/__tests__/matching.test.ts
+++ b/src/lib/responses/__tests__/matching.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  parseTestSequence,
   InputSchema,
   isMatchError,
   matchInput,
@@ -14,7 +15,12 @@ const messageItem = (
   position: number,
   role: MessageRole,
   content: string,
-  options?: { any_role?: boolean; any_content?: boolean; repeat?: boolean }
+  options?: {
+    any_role?: boolean;
+    any_content?: boolean;
+    repeat?: boolean;
+    content_contains?: string;
+  }
 ): TestItemRecord => ({
   id: `msg-${position}`,
   position,
@@ -210,6 +216,19 @@ describe("matchInput", () => {
       expect(result.outputItems).toHaveLength(1);
       expect(result.outputItems[0].type).toBe("message");
     }
+  });
+
+  it("keeps content_contains when parsing a stored sequence", () => {
+    const parsed = parseTestSequence([
+      {
+        id: "msg-0",
+        position: 0,
+        type: "message",
+        content: { role: "user", content: "", content_contains: "hello" },
+      },
+    ]);
+
+    expect(parsed[0].content).toMatchObject({ content_contains: "hello" });
   });
 
   it("matches content_contains against a prefixed body", () => {

--- a/src/lib/responses/matching.ts
+++ b/src/lib/responses/matching.ts
@@ -53,6 +53,7 @@ const StoredMessageContentSchema = z.object({
   // Wildcards are only meaningful for input (non-assistant) messages.
   any_role: z.boolean().optional(),
   any_content: z.boolean().optional(),
+  content_contains: z.string().optional(),
   repeat: z.boolean().optional(),
 });
 


### PR DESCRIPTION
- **Add MIT license**
- **Add content_contains matching for input messages**
- **Keep content_contains when reading a stored sequence**
